### PR TITLE
feat(CCM-108): Content refresh — Challenge to Incubator

### DIFF
--- a/components/ncTimeline.vue
+++ b/components/ncTimeline.vue
@@ -1,19 +1,15 @@
 <template>
   <ccm-base-section class="timeline | subgrid" background-color="gray">
     <div class="timeline__content">
-      <h2>Timeline</h2>
-      <p>Key dates for The New Commons Challenge:</p>
+      <h2>{{ title }}</h2>
+      <p>{{ subtitle }}</p>
       <div class="timeline__content-cards">
-        <div class="card" :class="{'active': i <= 4, 'full': i<=3}" v-for="i in 4" :key="i">
-          <h3>{{ new Date(timeline[i-1].date).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric', timeZone: 'Canada/Pacific' }) }}</h3>
+        <div class="card" :class="{'active': isActive(item), 'full': isFull(item, i)}" v-for="(item, i) in timeline" :key="i">
+          <h3>{{ formatDate(item.date) }}</h3>
           <span>
-            {{
-              new Date(timeline[i-1].date)
-                .toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', timeZoneName: 'shortGeneric', timeZone: 'Canada/Pacific' })
-                .replace(/AM/, 'a.m.').replace(/PM/, 'p.m.')
-            }}
+            {{ formatTime(item.date) }}
           </span>
-          <p>{{timeline[i-1].event}}</p>
+          <p>{{ item.event }}</p>
         </div>
       </div>
     </div>
@@ -22,25 +18,48 @@
 
 
 <script setup>
-// @TODO: Add this to the CMS
-const timeline = [
-  {
-    "date": "2025-04-14T00:00:00-07:00",
-    "event": "Start date of accepting concept notes"
+const props = defineProps({
+  timeline: {
+    type: Array,
+    required: true,
+    validator: (val) => val.every(item => 'date' in item && 'event' in item)
   },
-  {
-    "date": "2025-06-10T23:59:00-07:00",
-    "event": "End date of accepting concept notes"
-  },
-  {
-    "date": "2025-06-16T00:00:00-07:00",
-    "event": "Invitations to submit full proposal"
-  },
-  {
-    "date": "2025-07-14T23:59:00-07:00",
-    "event": "Full proposal submission closes"
-  }
-]
+  title: { type: String, default: 'Timeline' },
+  subtitle: { type: String, default: '' }
+})
+
+const now = new Date()
+
+function isActive(item) {
+  return now >= new Date(item.date)
+}
+
+function isFull(item, index) {
+  // A card is "full" (connecting line filled) if the next card is also active
+  const nextItem = props.timeline[index + 1]
+  return nextItem ? now >= new Date(nextItem.date) : false
+}
+
+function formatDate(dateStr) {
+  return new Date(dateStr).toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'Canada/Pacific'
+  })
+}
+
+function formatTime(dateStr) {
+  return new Date(dateStr)
+    .toLocaleTimeString('en-US', {
+      hour: '2-digit',
+      minute: '2-digit',
+      timeZoneName: 'shortGeneric',
+      timeZone: 'Canada/Pacific'
+    })
+    .replace(/AM/, 'a.m.')
+    .replace(/PM/, 'p.m.')
+}
 </script>
 
 <style scoped lang="scss">
@@ -112,10 +131,10 @@ content: '';
 }
 
 .timeline__content-cards .card.active::after {
-  background:  linear-gradient(90deg, #1E99FF 0%, #1E99FF 33.33%, #EAEAEA 66.67%, #EAEAEA 100%);
-} 
+  background: #eaeaea;
+}
 
 .timeline__content-cards .card.active.full::after {
-  background: linear-gradient(90deg, #1E99FF 0%, #1E99FF 33.33%, #1E99FF 66.67%, #1e99ff 100%);
+  background: var(--primary-color);
 }
 </style>

--- a/components/ncTimeline.vue
+++ b/components/ncTimeline.vue
@@ -4,7 +4,7 @@
       <h2>{{ title }}</h2>
       <p>{{ subtitle }}</p>
       <div class="timeline__content-cards">
-        <div class="card" :class="{'active': isActive(item), 'full': isFull(item, i)}" v-for="(item, i) in timeline" :key="i">
+        <div class="card" :class="{'active': isActive(item), 'full': isFull(item, i)}" v-for="(item, i) in timeline" :key="item.date">
           <h3>{{ formatDate(item.date) }}</h3>
           <span>
             {{ formatTime(item.date) }}
@@ -18,26 +18,31 @@
 
 
 <script setup>
+import { ref, onMounted } from 'vue'
+
 const props = defineProps({
   timeline: {
     type: Array,
-    required: true,
+    default: () => [],
     validator: (val) => val.every(item => 'date' in item && 'event' in item)
   },
   title: { type: String, default: 'Timeline' },
   subtitle: { type: String, default: '' }
 })
 
-const now = new Date()
+const now = ref(new Date())
+onMounted(() => {
+  now.value = new Date()
+})
 
 function isActive(item) {
-  return now >= new Date(item.date)
+  return now.value >= new Date(item.date)
 }
 
 function isFull(item, index) {
   // A card is "full" (connecting line filled) if the next card is also active
   const nextItem = props.timeline[index + 1]
-  return nextItem ? now >= new Date(nextItem.date) : false
+  return nextItem ? now.value >= new Date(nextItem.date) : false
 }
 
 function formatDate(dateStr) {
@@ -65,9 +70,6 @@ function formatTime(dateStr) {
 <style scoped lang="scss">
 .timeline {
   grid-column: full-start / full-end; /* Grid template columns are defined by the .subgrid class, and grid-column attr. */
-}
-
-.timeline {
 }
 
 .timeline__content {

--- a/docs/plans/CCM-108-content-refresh-incubator.md
+++ b/docs/plans/CCM-108-content-refresh-incubator.md
@@ -42,6 +42,48 @@ All placeholder content MUST follow these rules:
 - **Remove:** The commented-out "Join the Challenge Today" button.
 - **Add:** A new CTA button: "Apply to the Incubator" linking to `/incubator/2026` (or an external application form URL TBD).
 
+<details>
+<summary>Exact current content to remove (lines 4-11 of index.vue)</summary>
+
+```html
+<div class="panel | stack">
+  <h1>New Commons Challenge</h1>
+  <p>The <b>Open Data Policy Lab</b> invites global changemakers to propose innovative data commons for generative
+    AI that serves the public interest. By enhancing data diversity, quality, and provenance, we can unlock AI's
+    potential to innovate and solve complex challenges.</p>
+  <!--<nc-button el="a"
+    href="apply"
+    color="base"
+    variant="primary">Join the Challenge Today</nc-button>-->
+</div>
+```
+</details>
+
+<details>
+<summary>Before/After snippet</summary>
+
+```html
+<!-- BEFORE -->
+<div class="panel | stack">
+  <h1>New Commons Challenge</h1>
+  <p>The <b>Open Data Policy Lab</b> invites global changemakers to propose innovative data commons...</p>
+  <!--<nc-button ...>Join the Challenge Today</nc-button>-->
+</div>
+
+<!-- AFTER -->
+<div class="panel | stack">
+  <!-- TODO(CCM-108): Replace with client copy — hero headline and description -->
+  <h1>New Commons Incubator</h1>
+  <p>[PLACEHOLDER] The New Commons Incubator supports teams building data commons
+     for responsible AI. Through funding, mentorship, and technical resources, we help
+     turn promising ideas into sustainable shared data ecosystems.</p>
+  <nc-button el="a" to="/incubator/2026" color="base" variant="primary">Apply to the Incubator</nc-button>
+</div>
+```
+
+**Note:** `<nc-button>` auto-detects element type from attributes. Use `to` (renders as `NuxtLink`) for internal routes, `href` for external URLs. See `ncButton.vue` computed `defaultEl` logic: `attrs.to` -> `NuxtLink`, `attrs.href` -> `<a>`.
+</details>
+
 #### 1.2 Announcement bar — Replace with Incubator application CTA
 
 - **Replace** the "Meet the Awardees" announcement with an Incubator application CTA:
@@ -53,6 +95,47 @@ All placeholder content MUST follow these rules:
   ```
 - **Add** a secondary link: "View the 2025 Challenge" -> `/the-2025-challenge` (text link, not button). This satisfies the requirement to "add link to the 2025 Challenge archive page."
 
+**Component API notes:** `<nc-announcement>` accepts:
+- `color`: `'primary' | 'base' | 'accent' | 'success' | 'info' | 'cancel'` — controls background tint via `data-color` attribute
+- `content`: string — rendered as `<h3>` if no slot is provided
+- Default slot — overrides `content` prop entirely. The homepage currently uses the slot with a `.switcher` div containing text + button.
+
+The existing `.hero__announcement` scoped styles in `index.vue` (lines 110-140) handle the h3/h2/p typography. These styles remain unchanged since the new content follows the same element structure (h3 brow + h2 title + p description + button).
+
+<details>
+<summary>Before/After snippet</summary>
+
+```html
+<!-- BEFORE -->
+<nc-announcement color="primary" class="hero__announcement">
+  <div class="switcher" style="">
+    <div style="flex: 3;">
+      <h3>2025 New Commons Challenge</h3>
+      <h2>Meet the Awardees</h2>
+      <p>Explore the groundbreaking data commons recognized at the 2025 New Commons Showcase.</p>
+    </div>
+    <nc-button class="hero__announcement-button" to="/the-2025-challenge" color="primary" variant="primary" style="align-self: center;">View Awardees</nc-button>
+  </div>
+</nc-announcement>
+
+<!-- AFTER -->
+<nc-announcement color="primary" class="hero__announcement">
+  <!-- TODO(CCM-108): Replace with client copy — announcement bar -->
+  <div class="switcher" style="">
+    <div style="flex: 3;">
+      <h3>Now Accepting Applications</h3>
+      <h2>2026 Incubator Cohort</h2>
+      <p>[PLACEHOLDER] Apply by [DATE TBD] to join the next cohort of teams building data commons for responsible AI.</p>
+      <NuxtLink to="/the-2025-challenge" style="font-size: var(--size-0); font-weight: 300; text-decoration: underline;">View the 2025 Challenge &rarr;</NuxtLink>
+    </div>
+    <nc-button class="hero__announcement-button" to="/incubator/2026" color="primary" variant="primary" style="align-self: center;">Apply Now</nc-button>
+  </div>
+</nc-announcement>
+```
+
+**Edge case:** The secondary "View the 2025 Challenge" link is inline text within the `.switcher` div. It uses a NuxtLink rather than `<nc-button variant="link">` to avoid adding button padding. Alternatively, a `<nc-button>` with `color="base" variant="link"` would work, but it would inherit the announcement's `primary` color tinting. Inline NuxtLink is simpler.
+</details>
+
 #### 1.3 Video section — Keep embed, update text
 
 - **Keep:** The `<iframe>` YouTube embed and its container.
@@ -63,7 +146,17 @@ All placeholder content MUST follow these rules:
   ```
 - **Decision for implementer:** Confirm whether the same YouTube video URL stays or a new one will be provided. For now, keep the existing embed.
 
+**CSS context:** The `#video-section` uses `width="narrow"` on `<nc-base-section>`, which maps to `grid-column: col2 / col11` (see `ncBaseSection.vue` line 60-63). The `.panel` inside is centred with `max-width: 39.5rem` and `margin: 0 auto`. The gradient background (`linear-gradient(to bottom, white 50%, #f7f7f7 50%)`) creates the split-tone effect. All of this is preserved — only the text content of `<h2>` and `<p>` changes.
+
 #### 1.4 CTA section — Update FAQ panel + Webinar panel
+
+**Component API notes:** `<nc-cta>` accepts:
+- `singleColumn`: Boolean (default `false`) — when `true`, uses a single content slot spanning `content-start / content-end`. When `false`, splits into left (default slot, `content-start / col6`) and right (`right` slot, `col7 / content-end`).
+- The homepage uses `:single-column="true"` with a custom `.cta-panel` div inside the default slot.
+
+The `.cta-panel` is **not** a component — it is custom markup styled in `index.vue`'s scoped styles. It has two child divs:
+- `.panel-header` — dark teal background (`#0E2F40`) with `squares.svg` pattern, white text
+- `.panel-footer` — purple background (`rgba(88, 42, 142, 1)`) with `waves.png` pattern, white text
 
 - **FAQ panel (panel-header):**
   - Update text to reference Incubator FAQ:
@@ -71,6 +164,7 @@ All placeholder content MUST follow these rules:
     "Have questions about the Incubator?"
     ```
   - Keep the link to `/faq`.
+  - The FAQ link currently uses `<NuxtLink href="faq">` with a `.button` class and `color="white" variant="link"` attributes. Keep this pattern.
 - **Webinar panel (panel-footer):**
   - Replace Challenge webinar text with Incubator webinar placeholder:
     ```
@@ -78,6 +172,7 @@ All placeholder content MUST follow these rules:
     p:  "[PLACEHOLDER] Missed the live session? Watch our webinar to learn about the 2026 Incubator..."
     ```
   - Keep the "Watch now!" button pointing to `#video`.
+  - The button uses `color="wt" variant="primary2"` — this gives it a white background with dark text (see `ncButton.vue` lines 218-222).
 
 #### 1.5 Blog section — No changes
 
@@ -96,13 +191,28 @@ All placeholder content MUST follow these rules:
 ### Current State
 
 This page was created by CCM-105 as a copy of the old prize page with a placeholder banner. It currently contains:
-- A placeholder banner ("Coming Soon...")
-- Old prize hero with Challenge-era copy
-- "What are we looking for?" cards (Localized Decision-making / Humanitarian Interventions)
-- Prizes section with dollar amounts and support details
-- "Who can apply?" / Eligibility section
-- Helpful Tips section
-- Judges and Observers grids
+- A placeholder banner ("Coming Soon...") — `<nc-base-section class="placeholder-banner" color="primary">`
+- Old prize hero with Challenge-era copy — `<nc-hero>` with brow text "A Prize for a Shared Digital Future"
+- "What are we looking for?" cards — `<nc-base-section class="fancy-bg" width="narrow" color="primary">` with 2x `.prize-card` in a `.switcher`
+- Prizes section — `<nc-base-section class="prize-cta" id="cta" color="faded">` with `.cta-panel | switcher` containing prize list items and eligibility info
+- Helpful Tips section — `<nc-base-section class="prize-tips" subgrid color="faded">` with Blueprint and Inspirational Examples text
+- Judges and Observers grids — `<nc-base-section color="faded" size="l" id="judges">`
+
+**Script dependency:** The page currently imports `const { rulesUrl } = useSiteLinks()` (from `composables/useSiteLinks.js`). This composable returns `{ rulesUrl: 'https://docs.google.com/document/d/1fYmUkwTqOngtpbVT8BezgmWs14IkvGEO6q5a53jqHhA/...' }`. The `rulesUrl` is used in the Prizes section via `:href="rulesUrl"`. Since we are removing the Prizes section, we can remove this import entirely.
+
+<details>
+<summary>Full list of template content to remove (lines 2-105 of incubator/2026.vue)</summary>
+
+Everything from the opening `<nc-base-section class="placeholder-banner">` through the closing `</nc-base-section>` of `.prize-tips` will be replaced. Specifically:
+
+1. **Lines 2-6:** Placeholder banner
+2. **Lines 8-26:** Hero with Challenge copy and announcement bar (announcement bar content updates, structure stays)
+3. **Lines 28-42:** "What are we looking for?" section with fancy-bg and prize-cards
+4. **Lines 44-92:** Prize-cta section with prizes list and eligibility
+5. **Lines 94-105:** Prize-tips section with Blueprint and Inspirational Examples
+
+Lines 107-113 (Judges/Observers) are **kept as-is**.
+</details>
 
 ### Target Structure
 
@@ -111,83 +221,283 @@ Replace everything above the judges grid with proper Incubator content. The page
 #### 2.1 Hero
 
 - **Remove** the placeholder banner (`<nc-base-section class="placeholder-banner">`).
-- **Replace** hero content:
-  ```
-  Brow:  "2026 Cohort"
-  h1:    "The New Commons Incubator"
-  p:     "[PLACEHOLDER] The New Commons Incubator is a 12-month programme that provides..."
-  ```
+- **Replace** hero content.
 - **Keep** the announcement bar linking to the 2025 Challenge (already present, just update copy if needed).
+
+**`<nc-hero>` API:** Pure slot-based component — no props. Renders a `div.hero.subgrid` that spans `full-start / full-end` with `grid-template-columns: subgrid`. Children are placed at `content-start / content-end`. The `.hero__content` class (styled via `:deep`) creates a flex row with `gap: var(--space-2xl-3xl)` and `align-items: center`.
+
+The current page uses a `.panel` div with a `.hero__brow` paragraph. The scoped `.panel` styles (lines 122-135 of 2026.vue) set `max-width: 80ch`, font sizes, and the brow styling (uppercase, primary color, font-weight 800). These styles should be kept but the brow text and content updated.
+
+**Note:** Unlike the homepage hero, the incubator hero does NOT have a `hero__image-div` with the animated logo. It is text-only. A hero image could be added to match the homepage pattern, but this is a design decision — leave text-only for now.
+
+<details>
+<summary>Before/After snippet</summary>
+
+```html
+<!-- BEFORE (lines 2-26) -->
+<nc-base-section class="placeholder-banner" color="primary">
+  <p><strong>Coming Soon:</strong> The 2026 Incubator programme details are being finalised...</p>
+</nc-base-section>
+
+<nc-hero>
+  <div class="hero__content">
+    <div class="panel">
+      <p class="hero__brow">A Prize for a Shared Digital Future</p>
+      <h1>The Incubator — 2026 Cohort</h1>
+      <p>The New Commons Challenge is an initiative led by Microsoft...</p>
+      <p>The challenge addresses a critical issue...</p>
+    </div>
+  </div>
+  <nc-announcement color="primary" class="hero__announcement">
+    <div class="switcher">
+      <div style="flex: 3;">
+        <h2>Learn about the 2025 Challenge winners and honorary distinctions</h2>
+        <p>See the groundbreaking data commons recognised at the 2025 New Commons Showcase.</p>
+      </div>
+      <nc-button class="hero__announcement-button" to="/the-2025-challenge" color="primary" variant="primary" style="align-self: center;">The 2025 Challenge</nc-button>
+    </div>
+  </nc-announcement>
+</nc-hero>
+
+<!-- AFTER -->
+<nc-hero>
+  <div class="hero__content">
+    <div class="panel">
+      <!-- TODO(CCM-108): Replace with client copy — incubator hero brow, heading, and description -->
+      <p class="hero__brow">2026 Cohort</p>
+      <h1>The New Commons Incubator</h1>
+      <p>[PLACEHOLDER] The New Commons Incubator is a 12-month programme that provides
+         selected teams with funding, mentorship, and technical resources to build or
+         strengthen data commons for responsible AI development.</p>
+    </div>
+  </div>
+  <nc-announcement color="primary" class="hero__announcement">
+    <div class="switcher">
+      <div style="flex: 3;">
+        <!-- TODO(CCM-108): Replace with client copy — 2025 challenge archive link text -->
+        <h2>Explore the 2025 New Commons Challenge</h2>
+        <p>[PLACEHOLDER] See the winning data commons and honorary distinctions from the inaugural Challenge.</p>
+      </div>
+      <nc-button class="hero__announcement-button" to="/the-2025-challenge" color="primary" variant="primary" style="align-self: center;">The 2025 Challenge</nc-button>
+    </div>
+  </nc-announcement>
+</nc-hero>
+```
+</details>
 
 #### 2.2 Program Overview section (NEW)
 
 - Use `<nc-base-section>` with a simple two-column layout (text + optional image or icon).
-- Content structure:
-  ```html
+- Can reuse the existing `.switcher` layout pattern already defined in the page's scoped styles (line 155-157: `--_switcher-space: var(--space-s)`).
+
+**`<nc-base-section>` API:**
+- `width`: `'content'` (default) | `'narrow'` — narrow constrains to `col2 / col11`
+- `color`: `''` (transparent) | `'base'` | `'primary'` | `'secondary'` | `'faded'` — sets background and text color
+- `subgrid`: Boolean — enables CSS subgrid on the content div
+
+```html
+<!-- TODO(CCM-108): Replace with client copy — program overview -->
+<nc-base-section>
   <h2>Program Overview</h2>
-  <p>[PLACEHOLDER] The Incubator provides selected teams with funding, mentorship,
-     and technical resources to build or enhance data commons for responsible AI...</p>
-  ```
-- Can reuse the existing `.switcher` layout pattern.
+  <div class="switcher">
+    <div class="stack">
+      <p>[PLACEHOLDER] The New Commons Incubator is a 12-month programme run by the
+         Open Data Policy Lab that helps teams build and sustain data commons for
+         responsible AI development. Each cohort receives tailored support to move
+         from concept to implementation.</p>
+      <p>[PLACEHOLDER] Building on the success of the New Commons Challenge, the Incubator
+         takes a deeper, hands-on approach — working closely with selected teams to
+         address technical, governance, and sustainability challenges.</p>
+    </div>
+    <div>
+      <!-- Optional: image or illustration. Could reuse /assets/patterns/hero.jpg or a new asset -->
+    </div>
+  </div>
+</nc-base-section>
+```
+
+**CSS note:** The `.switcher` class is a global utility (not just scoped) that creates a responsive two-column layout. The page overrides `--_switcher-space` to `var(--space-s)`. No new styles needed for this section.
 
 #### 2.3 "What We Offer" section (REPLACES old "What are we looking for?" + Prizes)
 
-- Use the existing two-card layout (`.prize-card` pattern) but rename the CSS class to something like `.offer-card`.
-- Cards (3-4 items, using icon + title + description pattern already in use):
-  ```
-  Card 1: Funding — "[PLACEHOLDER] Up to $X in grant funding..."
-  Card 2: Mentorship & Guidance — "[PLACEHOLDER] Access to experts in data governance..."
-  Card 3: Technical Support — "[PLACEHOLDER] Hands-on technical assistance..."
-  Card 4: Network Access — "[PLACEHOLDER] Connect with the Open Data Policy Lab's global network..."
-  ```
-- **Implementation note:** The existing `.prize-card` grid layout works well. Reuse the icon assets (`/assets/trophy.svg`, `/assets/mentorship.svg`, `/assets/support.svg`, `/assets/globe.svg`) — they are generic enough.
+- Use the existing card layout but rename CSS class from `.prize-card` to `.offer-card`.
+- Expand from 2 cards to 4 cards (icon + title + description pattern).
+
+**Available SVG icons** (all in `/public/assets/`):
+- `money.svg` — dollar sign icon, good for Funding
+- `mentorship.svg` — people/guidance icon, good for Mentorship
+- `support.svg` — wrench/tools icon, good for Technical Support
+- `globe.svg` — globe icon, good for Network Access
+- `trophy.svg` — trophy icon (less relevant for Incubator)
+- `icon-globe.svg` — alternative globe, used in current "What are we looking for?" cards
+- `icon-people.svg` — people icon, used in current Humanitarian Interventions card
+
+**Current `.prize-card` CSS pattern** (lines 159-188 of 2026.vue) — this is the layout to reuse:
+```css
+.prize-card {  /* rename to .offer-card */
+  background-color: var(--white-color);
+  padding: 2.5rem;
+  border-radius: var(--border-radius-m);
+  color: var(--base-color);
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto 1fr;
+  grid-template-areas:
+    "icon title"
+    "icon description";
+  gap: var(--space-s);
+  /* img -> grid-area: icon; h3 -> grid-area: title; p -> grid-area: description */
+}
+```
+
+**Layout change:** Currently the cards sit inside a `.switcher` (2 columns). With 4 cards, use a CSS grid instead:
+```css
+.offer-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--space-s);
+}
+```
+
+The `.fancy-bg` parent section (dark blue with `bg-prize.png` background) can be kept or changed. Recommendation: keep the `color="primary"` section background for visual contrast but consider dropping `width="narrow"` to give 4 cards more room.
+
+```html
+<!-- TODO(CCM-108): Replace with client copy — what we offer cards -->
+<nc-base-section class="fancy-bg" color="primary">
+  <h2 class="text-align:center padding-block:l white-color h2">What We Offer</h2>
+  <div class="offer-cards">
+    <div class="offer-card">
+      <img src="/assets/money.svg" alt="Funding">
+      <h3>Funding</h3>
+      <p>[PLACEHOLDER] Up to $X in grant funding to support the development or enhancement of your data commons over 12 months.</p>
+    </div>
+    <div class="offer-card">
+      <img src="/assets/mentorship.svg" alt="Mentorship">
+      <h3>Mentorship &amp; Guidance</h3>
+      <p>[PLACEHOLDER] Regular access to experts in data governance, AI ethics, and commons management from the Open Data Policy Lab network.</p>
+    </div>
+    <div class="offer-card">
+      <img src="/assets/support.svg" alt="Technical Support">
+      <h3>Technical Support</h3>
+      <p>[PLACEHOLDER] Hands-on technical assistance with data infrastructure, interoperability standards, and platform development.</p>
+    </div>
+    <div class="offer-card">
+      <img src="/assets/globe.svg" alt="Network Access">
+      <h3>Network Access</h3>
+      <p>[PLACEHOLDER] Connect with the Open Data Policy Lab's global network of policymakers, technologists, and data practitioners.</p>
+    </div>
+  </div>
+</nc-base-section>
+```
 
 #### 2.4 "Who Should Apply" section (REPLACES old eligibility)
 
-- Use `<nc-base-section color="faded">`.
-- Structure:
-  ```html
-  <h2>Who Should Apply</h2>
-  <p>[PLACEHOLDER] We welcome applications from nonprofits, academic institutions,
-     startups, and development organisations working with data commons...</p>
-  <h3>Eligibility Criteria</h3>
-  <ul>
-    <li>[PLACEHOLDER] Must be affiliated with an established organisation...</li>
-    <li>[PLACEHOLDER] Project must focus on data commons for AI...</li>
-    <li>[PLACEHOLDER] Must demonstrate capacity to implement over 12 months...</li>
-  </ul>
-  ```
+- Use `<nc-base-section color="faded">` — renders with `var(--base-color-07-tint)` background and `var(--base-color)` text.
+- Reuses the `.cta-panel | switcher` pattern from the current Prizes section for a two-column layout (left: heading + CTA, right: criteria details).
+
+**Current pattern being replaced** (lines 78-91 of 2026.vue): The "Who can apply?" section uses a `.cta-panel | switcher` with an h2 on the left and eligibility text + link buttons on the right. We keep this same structural pattern but update content.
+
+```html
+<!-- TODO(CCM-108): Replace with client copy — eligibility section -->
+<nc-base-section color="faded">
+  <div class="cta-panel | switcher">
+    <div>
+      <h2>Who Should Apply</h2>
+    </div>
+    <div class="stack" style="--_stack-space: var(--space-2xs)">
+      <p>[PLACEHOLDER] We welcome applications from nonprofits, academic institutions,
+         startups, and development organisations working to build or strengthen
+         data commons for responsible AI.</p>
+      <h3 class="margin-top:s">Eligibility Criteria</h3>
+      <ul>
+        <li>[PLACEHOLDER] Must be affiliated with an established organisation capable of managing funds</li>
+        <li>[PLACEHOLDER] Project must focus on data commons that support responsible AI development</li>
+        <li>[PLACEHOLDER] Must demonstrate capacity to implement over 12 months</li>
+        <li>[PLACEHOLDER] Government entities may not apply as lead applicants</li>
+      </ul>
+    </div>
+  </div>
+</nc-base-section>
+```
+
+**CSS reuse note:** The `.cta-panel` styles (lines 190-207) give white text on dark/purple backgrounds. Since this section uses `color="faded"` (light grey bg), the white text would be invisible. The `.cta-panel` styles need modification for this context — either:
+- (a) Remove the `.cta-panel` class and use plain markup in the `faded` section, or
+- (b) Add a `.cta-panel--light` modifier that does not set `color: var(--white-color)`.
+
+**Risk:** The current `.cta-panel` applies `color: var(--white-color)` unconditionally (line 192). If reused inside `color="faded"`, all text becomes white-on-light-grey = invisible. Recommendation: do NOT reuse `.cta-panel` here. Use a plain `.switcher` div with no color override.
 
 #### 2.5 Timeline section
 
-- **Option A (recommended):** Reuse the existing `<nc-timeline>` component. It is already built and supports a card-based visual timeline. Update the data array in the component or pass timeline data as props.
-  - The current `ncTimeline.vue` has hardcoded Challenge dates. For the Incubator, either:
-    - (a) Make the component accept a `timeline` prop (preferred — keeps it reusable), or
-    - (b) Create a new inline timeline in the page using the same CSS pattern.
-- **Option B (simpler):** Build a simple inline ordered list styled as a vertical timeline. Less visual but faster to implement.
-- **Recommended approach:** Option A — refactor `<nc-timeline>` to accept a `timeline` prop with a default fallback. Then use it in the Incubator page:
-  ```html
-  <nc-timeline :timeline="incubatorTimeline" />
-  ```
-  ```js
-  const incubatorTimeline = [
-    { date: '2026-03-01T00:00:00Z', event: '[PLACEHOLDER] Applications open' },
-    { date: '2026-05-01T00:00:00Z', event: '[PLACEHOLDER] Applications close' },
-    { date: '2026-06-15T00:00:00Z', event: '[PLACEHOLDER] Cohort announced' },
-    { date: '2026-09-01T00:00:00Z', event: '[PLACEHOLDER] Programme begins' },
-  ]
-  ```
+**Current `<nc-timeline>` component analysis** (`components/ncTimeline.vue`):
+
+The component is currently NOT prop-driven. Key details:
+- Uses `<ccm-base-section>` (NOT `<nc-base-section>`) — this is a lower-level grid component
+- Has a hardcoded `timeline` array of 4 items with `{ date: string, event: string }` shape
+- Renders exactly 4 cards via `v-for="i in 4"` (hardcoded count!)
+- Uses `timeline[i-1]` indexing (1-based loop)
+- Date formatting: `toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric', timeZone: 'Canada/Pacific' })`
+- Time formatting: `toLocaleTimeString(...)` with AM/PM replacement
+- Progress indicator: cards get `.active` class when `i <= 4` and `.full` class when `i <= 3` — this is currently static (all cards active). Originally this was meant to show progress through the challenge timeline.
+- The component is currently **commented out** in `index.vue` (line 43: `<!--<nc-timeline id="timeline" />-->`)
+
+**Refactor required:** To accept a `timeline` prop:
+
+```vue
+<!-- ncTimeline.vue — refactored -->
+<script setup>
+const props = defineProps({
+  timeline: {
+    type: Array,
+    required: true,
+    validator: (val) => val.every(item => 'date' in item && 'event' in item)
+  },
+  title: { type: String, default: 'Timeline' },
+  subtitle: { type: String, default: '' }
+})
+</script>
+```
+
+The `v-for="i in 4"` must change to `v-for="(item, i) in timeline"`. The `.active` / `.full` classes should be driven by comparing `new Date(item.date)` against today's date.
+
+**Risk:** The timeline progress bar CSS uses `::before` (dot) and `::after` (connecting line) pseudo-elements on each `.card`. The gradient on `.active::after` is hardcoded to work with exactly 4 cards (33.33% stops). With a different number of cards, the gradient percentages would need recalculating or switching to a simpler solid colour.
+
+**Recommendation:** Option A — refactor the component. The `v-for` and prop changes are straightforward. For the gradient issue, use a simple solid-colour bar (`background: var(--primary-color)`) for active segments instead of the percentage-based gradient. This works for any number of cards.
+
+```js
+// In the incubator page's <script setup>:
+const incubatorTimeline = [
+  { date: '2026-03-01T00:00:00-05:00', event: '[PLACEHOLDER] Applications open' },
+  { date: '2026-05-01T00:00:00-04:00', event: '[PLACEHOLDER] Applications close' },
+  { date: '2026-06-15T00:00:00-04:00', event: '[PLACEHOLDER] Cohort announced' },
+  { date: '2026-09-01T00:00:00-04:00', event: '[PLACEHOLDER] Programme begins' },
+]
+```
+
+```html
+<nc-timeline :timeline="incubatorTimeline" title="Timeline" subtitle="Key dates for the 2026 Incubator:" />
+```
 
 #### 2.6 Application CTA section
 
 - Use the existing CTA panel pattern (dark background + button).
-- Content:
-  ```html
-  <h2>Ready to Apply?</h2>
-  <p>[PLACEHOLDER] Submit your application by [DATE TBD]...</p>
-  <nc-button color="primary" variant="primary">Apply Now</nc-button>
-  ```
+- Reuse the `.cta-panel` CSS which provides `color: var(--white-color)`, dark `background-color: var(--base-color)`, and `border-radius`.
 - The button href is TBD (external Google Form or built-in form).
+
+```html
+<!-- TODO(CCM-108): Replace with client copy — application CTA -->
+<nc-base-section>
+  <div class="cta-panel" style="border-radius: var(--border-radius-m);">
+    <div class="stack" style="text-align: center; max-width: 40rem; margin: 0 auto;">
+      <h2>Ready to Apply?</h2>
+      <p>[PLACEHOLDER] Submit your application by [DATE TBD]. Selected teams will be
+         notified by [DATE TBD] and the programme begins in [MONTH TBD] 2026.</p>
+      <nc-button href="#" color="primary" variant="primary">Apply Now</nc-button>
+    </div>
+  </div>
+</nc-base-section>
+```
+
+**Note:** The `href="#"` is a placeholder. When the application URL is confirmed, it will be an external Google Form URL (use `href`) or internal route (use `to`). The `<nc-button>` auto-detects: `href` renders `<a>`, `to` renders `<NuxtLink>`.
 
 #### 2.7 Judges & Observers — KEEP
 
@@ -207,9 +517,22 @@ Replace everything above the judges grid with proper Incubator content. The page
 
 ### Style changes
 
-- Rename `.prize-card` to `.offer-card` (or keep the class name and just change content — implementer's call on cleanliness).
-- Remove `.prize-cta`, `.prize-list`, `.prize-tips` styles that are no longer used.
-- Add any new styles for the timeline if building inline.
+**Styles to REMOVE** (dead CSS after content removal):
+- `.fancy-bg` (lines 139-145) — only if the "What We Offer" section no longer uses the `bg-prize.png` background. If kept with `color="primary"`, this class can be reused but rename to something like `.offer-bg`.
+- `.prize-cta` (lines 147-153) — the overlap/negative-margin trick for the prizes panel. No longer needed.
+- `.prize-card` (lines 159-188) — rename to `.offer-card` and keep the grid layout.
+- `.cta-panel` (lines 190-207) — keep for the Application CTA section (2.6), but remove the `:first-child` / `:last-child` radius rules that assumed two stacked panels. The CTA section only has one panel.
+- `.prize-list` (lines 209-232) — the icon + text list for prizes. Remove entirely.
+- `.prize-tips` (lines 234-252) — the subgrid layout for helpful tips. Remove entirely.
+
+**Styles to ADD:**
+- `.offer-card` — copy from `.prize-card` with same grid layout
+- `.offer-cards` — new container grid for 4 cards: `display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: var(--space-s);`
+
+**Styles to KEEP unchanged:**
+- `.panel` (lines 122-135) — hero panel styles
+- `.hero__announcement` (lines 253-283) — announcement bar in hero
+- `.switcher` override (lines 155-157) — `--_switcher-space: var(--space-s)`
 
 ---
 
@@ -243,40 +566,233 @@ Replace all 8 categories with Incubator-relevant categories. Suggested grouping:
 | `timeline` | Timeline & Key Dates | When things happen |
 | `governance` | Data Governance | How data commons should be governed, requirements |
 
-### Implementation
+### Exact FAQ data format
 
-1. **Keep the template structure exactly as-is** — just update `v-for` bindings if category keys change, and update the `<h3>` headings.
-2. **Replace the `faq` object** in `<script setup>` with new placeholder Q&A pairs.
-3. Each Q&A item follows the existing shape: `{ summary: string, content: string }`.
-4. Prefix all answer content with `<!-- TODO(CCM-108): Replace with client copy -->`.
-5. Write 2-4 placeholder questions per category (matching realistic Incubator topics).
+The `<nc-collapse>` component expects a `data` prop with this shape:
+```ts
+{ summary: string, content: string }
+```
+- `summary` — plain text, rendered inside `<h4>` in a `<summary>` element (the clickable accordion header)
+- `content` — raw HTML string, rendered via `v-html` inside a `<div>` (supports `<p>`, `<ul>`, `<a>`, etc.)
+- The `name` prop on `<nc-collapse>` groups accordions so only one can be open at a time within a group (uses the HTML `<details name="...">` attribute)
 
-### Example placeholder items
+The FAQ page template has one `<nc-faq-section>` per category. Each section contains:
+1. An `<h3 class="h3">` heading (the category title)
+2. Multiple `<nc-collapse>` items via `v-for`
+
+The `<nc-faq-section>` component is a thin wrapper around `<nc-base-section>` that adds a responsive subgrid layout:
+- On desktop (>768px): the `<h3>` heading spans `content-start / col4` (left column) and the `<details>` accordions span `col5 / content-end` (right column)
+- On mobile: single column, stacked
+
+### Template changes
+
+The template must be updated to match the new category keys. Currently there are 8 `<nc-faq-section>` blocks; replace with 6.
+
+**Important:** The first section has `background-color="transparent"` and the last has `class="last-item"` (adds bottom margin). Preserve these.
+
+```html
+<!-- BEFORE: 8 sections with keys: information, eligibility, application, scope, criteria, decision, support, timeline -->
+<!-- AFTER: 6 sections with keys: program, eligibility, application, support, timeline, governance -->
+
+<nc-faq-section background-color="transparent">
+  <h3 class="h3">About the Incubator</h3>
+  <nc-collapse name="program" v-for="item in faq.program" :key="item.summary" :data="item" />
+</nc-faq-section>
+<nc-faq-section>
+  <h3 class="h3">Eligibility</h3>
+  <nc-collapse name="eligibility" v-for="item in faq.eligibility" :key="item.summary" :data="item" />
+</nc-faq-section>
+<nc-faq-section>
+  <h3 class="h3">Application Process</h3>
+  <nc-collapse name="application" v-for="item in faq.application" :key="item.summary" :data="item" />
+</nc-faq-section>
+<nc-faq-section>
+  <h3 class="h3">Support &amp; Resources</h3>
+  <nc-collapse name="support" v-for="item in faq.support" :key="item.summary" :data="item" />
+</nc-faq-section>
+<nc-faq-section>
+  <h3 class="h3">Timeline &amp; Key Dates</h3>
+  <nc-collapse name="timeline" v-for="item in faq.timeline" :key="item.summary" :data="item" />
+</nc-faq-section>
+<nc-faq-section class="last-item">
+  <h3 class="h3">Data Governance</h3>
+  <nc-collapse name="governance" v-for="item in faq.governance" :key="item.summary" :data="item" />
+</nc-faq-section>
+```
+
+### Complete placeholder FAQ data
 
 ```js
-program: [
-  {
-    summary: 'What is the New Commons Incubator?',
-    content: `
-      <!-- TODO(CCM-108): Replace with client copy — program description -->
-      <p>[PLACEHOLDER] The New Commons Incubator is a programme run by the Open Data Policy Lab
-         that supports teams in building and sustaining data commons for responsible AI development...</p>
-    `
-  },
-  {
-    summary: 'What do Incubator participants receive?',
-    content: `
-      <!-- TODO(CCM-108): Replace with client copy — participant benefits -->
-      <p>[PLACEHOLDER] Participants receive funding, mentorship, technical support,
-         and access to the Open Data Policy Lab's global network of experts...</p>
-    `
-  },
-]
+const faq = {
+  program: [
+    {
+      summary: 'What is the New Commons Incubator?',
+      content: `
+        <!-- TODO(CCM-108): Replace with client copy — program description -->
+        <p>[PLACEHOLDER] The New Commons Incubator is a 12-month programme run by the Open Data Policy Lab
+           that supports teams in building and sustaining data commons for responsible AI development.
+           It builds on the success of the New Commons Challenge by providing deeper, hands-on support.</p>
+      `
+    },
+    {
+      summary: 'What do Incubator participants receive?',
+      content: `
+        <!-- TODO(CCM-108): Replace with client copy — participant benefits -->
+        <p>[PLACEHOLDER] Each selected team receives:</p>
+        <ul>
+          <li>Grant funding (amount TBD)</li>
+          <li>Mentorship from experts in data governance and AI ethics</li>
+          <li>Technical support for data infrastructure and platform development</li>
+          <li>Access to the Open Data Policy Lab's global network</li>
+        </ul>
+      `
+    },
+    {
+      summary: 'Who runs the Incubator?',
+      content: `
+        <!-- TODO(CCM-108): Replace with client copy — organisers -->
+        <p>[PLACEHOLDER] The New Commons Incubator is an initiative of the
+           <a href="https://opendatapolicylab.org/" target="_blank" rel="noopener">Open Data Policy Lab</a>,
+           a collaboration between The GovLab at New York University and Microsoft.</p>
+      `
+    },
+    {
+      summary: 'How is the Incubator different from the Challenge?',
+      content: `
+        <!-- TODO(CCM-108): Replace with client copy — challenge vs incubator -->
+        <p>[PLACEHOLDER] While the Challenge was a competitive prize programme that selected two winners,
+           the Incubator takes a cohort-based approach, providing sustained support over 12 months to
+           multiple teams working on data commons for responsible AI.</p>
+      `
+    },
+  ],
+  eligibility: [
+    {
+      summary: 'Who can apply to the Incubator?',
+      content: `
+        <!-- TODO(CCM-108): Replace with client copy — eligibility overview -->
+        <p>[PLACEHOLDER] We welcome applications from nonprofits, academic institutions, startups,
+           and development organisations working with data commons. Applicants must be affiliated
+           with an established institution capable of managing funds.</p>
+      `
+    },
+    {
+      summary: 'Are there geographic restrictions?',
+      content: `
+        <!-- TODO(CCM-108): Replace with client copy — geographic eligibility -->
+        <p>[PLACEHOLDER] The Incubator is a global programme. We welcome applications from
+           organisations worldwide, though we may be unable to deliver support to entities
+           subject to sanctions under U.S. law.</p>
+      `
+    },
+    {
+      summary: 'Can government agencies apply?',
+      content: `
+        <!-- TODO(CCM-108): Replace with client copy — government eligibility -->
+        <p>[PLACEHOLDER] Government entities may not apply as lead applicants but may participate
+           as collaborators or partners on a project.</p>
+      `
+    },
+  ],
+  application: [
+    {
+      summary: 'How do I apply?',
+      content: `
+        <!-- TODO(CCM-108): Replace with client copy — application process -->
+        <p>[PLACEHOLDER] Applications are submitted through our online form. You will need to
+           provide information about your organisation, your proposed data commons project,
+           and a letter of institutional support.</p>
+      `
+    },
+    {
+      summary: 'What is the application deadline?',
+      content: `
+        <!-- TODO(CCM-108): Replace with client copy — deadline -->
+        <p>[PLACEHOLDER] The application deadline is [DATE TBD]. Late applications will not
+           be considered.</p>
+      `
+    },
+    {
+      summary: 'Can my organisation submit multiple applications?',
+      content: `
+        <!-- TODO(CCM-108): Replace with client copy — multiple applications -->
+        <p>[PLACEHOLDER] Each organisation may submit one application. If you need to revise
+           a submission, contact us at
+           <a href="mailto:newcommons@opendatapolicylab.org">newcommons@opendatapolicylab.org</a>.</p>
+      `
+    },
+  ],
+  support: [
+    {
+      summary: 'What kind of mentorship is provided?',
+      content: `
+        <!-- TODO(CCM-108): Replace with client copy — mentorship details -->
+        <p>[PLACEHOLDER] Selected teams are paired with mentors from the Open Data Policy Lab
+           network who have expertise in data governance, AI ethics, and commons management.
+           Mentorship sessions are held regularly throughout the 12-month programme.</p>
+      `
+    },
+    {
+      summary: 'What technical support is available?',
+      content: `
+        <!-- TODO(CCM-108): Replace with client copy — technical support -->
+        <p>[PLACEHOLDER] Teams receive hands-on technical assistance with data infrastructure,
+           interoperability standards, and platform development. The specifics are tailored
+           to each team's needs and stage of development.</p>
+      `
+    },
+  ],
+  timeline: [
+    {
+      summary: 'What are the key dates for the 2026 Incubator?',
+      content: `
+        <!-- TODO(CCM-108): Replace with client copy — key dates -->
+        <p>[PLACEHOLDER] Key dates:</p>
+        <ul>
+          <li><strong>[DATE TBD]</strong> — Applications open</li>
+          <li><strong>[DATE TBD]</strong> — Applications close</li>
+          <li><strong>[DATE TBD]</strong> — Cohort announced</li>
+          <li><strong>[DATE TBD]</strong> — Programme begins</li>
+        </ul>
+      `
+    },
+    {
+      summary: 'How long is the Incubator programme?',
+      content: `
+        <!-- TODO(CCM-108): Replace with client copy — programme duration -->
+        <p>[PLACEHOLDER] The Incubator runs for approximately 12 months from the programme
+           start date. Teams are expected to make significant progress on their data commons
+           within this timeframe.</p>
+      `
+    },
+  ],
+  governance: [
+    {
+      summary: 'What governance structures are expected for data commons?',
+      content: `
+        <!-- TODO(CCM-108): Replace with client copy — governance expectations -->
+        <p>[PLACEHOLDER] Applicants should articulate how their data commons will be
+           responsibly governed, including who will be involved in oversight and strategic
+           decisions about data access and use.</p>
+      `
+    },
+    {
+      summary: 'Are there specific data governance frameworks we should follow?',
+      content: `
+        <!-- TODO(CCM-108): Replace with client copy — governance frameworks -->
+        <p>[PLACEHOLDER] While we do not mandate a specific framework, applicants may find it
+           useful to refer to the Open Data Policy Lab's
+           <a href="https://incubator.opendatapolicylab.org/files/data-commons-for-ai-blueprint.pdf" target="_blank" rel="noopener">
+           Blueprint to Unlock New Data Commons for AI</a> for guidance on governance approaches.</p>
+      `
+    },
+  ],
+}
 ```
 
 ### Style changes
 
-- None. Keep existing styles as-is.
+- None. Keep existing styles as-is. The `.title`, `.last-item`, `<nc-faq-section>`, and `<nc-collapse>` styles all work unchanged with the new content.
 
 ---
 
@@ -312,3 +828,21 @@ Recommended sequence:
 4. **Offer amounts:** The old page showed "USD 100,000" grants. The Incubator funding structure may differ. Use generic "[PLACEHOLDER] Up to $X" until confirmed.
 5. **Rules link:** The topbar still has a "Rules" link (`useSiteLinks().rulesUrl`). Does this need updating for the Incubator, or does it stay as the Challenge rules? Leave as-is for now — this is outside CCM-108 scope.
 6. **"Helpful Tips" content:** The old prize page had Blueprint and Inspirational Examples links. Should any of this content carry over to the Incubator page, perhaps in a "Resources" subsection? Assume no unless client requests it.
+
+---
+
+## 7. Risks & Edge Cases Discovered During Research
+
+1. **`.cta-panel` white-text-on-light-background bug:** The `.cta-panel` class in `incubator/2026.vue` unconditionally sets `color: var(--white-color)`. If reused inside a `color="faded"` section (light grey background), text becomes invisible. The "Who Should Apply" section (2.4) must NOT use `.cta-panel` — use a plain `.switcher` instead.
+
+2. **`ncTimeline.vue` hardcoded to exactly 4 items:** The `v-for="i in 4"` loop and the CSS gradient stops (`33.33%`) are designed for exactly 4 timeline cards. Refactoring to accept a prop requires updating both the loop and the progress bar CSS. If the Incubator timeline ends up with more or fewer than 4 items, the gradient-based progress bar breaks. Use solid colour for active segments.
+
+3. **`ncTimeline.vue` uses `<ccm-base-section>`, not `<nc-base-section>`:** The timeline component wraps content in `<ccm-base-section>` (the lower-level grid primitive), while the rest of the page uses `<nc-base-section>` (the higher-level wrapper). This is intentional — `ncTimeline` manages its own grid column placement via the `.timeline` class. Do not change this.
+
+4. **Offer cards layout — 4 cards in `.switcher` may stack wrong:** The `.switcher` utility is designed for 2-column layouts. With 4 `.offer-card` items, it would create 2 rows of 2 on desktop but may stack to 4 rows of 1 on mobile earlier than desired. Use a dedicated `.offer-cards` grid container instead of `.switcher` for the 4-card layout.
+
+5. **`useSiteLinks()` removal from incubator page:** The composable is imported but only used for `rulesUrl` in the Prizes section being removed. Safe to remove the import. However, verify `useSiteLinks()` is not used elsewhere on this page before deleting — confirmed: it is only used once (line 118, `const { rulesUrl } = useSiteLinks()`).
+
+6. **FAQ `name` attribute grouping:** Each `<nc-faq-section>` uses a different `name` value on `<nc-collapse>` (e.g., `name="challenge"`, `name="eligibility"`). This ensures that within each section, opening one accordion closes others. When changing category keys, the `name` values must match the new groupings (e.g., `name="program"`, `name="governance"`) to maintain this exclusive-open behaviour.
+
+7. **Commented-out blog section on incubator page:** Line 114 of `incubator/2026.vue` has `<!--<nc-blog-section id="blog" :posts="blogposts" />-->`. This is currently commented out and there is no `blogposts` query in `<script setup>`. If this should be re-enabled for the Incubator page, a `useAsyncData` query (matching the homepage pattern) would need to be added. Plan assumes it stays commented out.

--- a/docs/plans/CCM-108-content-refresh-incubator.md
+++ b/docs/plans/CCM-108-content-refresh-incubator.md
@@ -1,0 +1,314 @@
+# CCM-108: Content Refresh & Incubator Page — Implementation Plan
+
+## Overview
+
+Replace Challenge-era content across three pages (homepage, incubator/2026, FAQ) with Incubator-era content. Nearly all final copy is blocked on client input, so the implementation focuses on building the correct **structure and layout** with realistic placeholder text that is trivially swappable.
+
+### Placeholder Convention
+
+All placeholder content MUST follow these rules:
+
+1. Wrap every placeholder block with an HTML comment:
+   ```html
+   <!-- TODO(CCM-108): Replace with client copy — [description of what goes here] -->
+   ```
+2. Prefix visible placeholder text with `[PLACEHOLDER]` so it is instantly recognisable in the browser.
+3. Keep placeholder text realistic in length and tone so the page looks right in demos.
+
+---
+
+## 1. Homepage Rewrite (`pages/index.vue`)
+
+### Current Structure (top to bottom)
+
+| Section | Component | Current Content |
+|---------|-----------|-----------------|
+| Hero | `<nc-hero>` | "New Commons Challenge" intro + hero image |
+| Announcement bar | `<nc-announcement>` | "Meet the Awardees" CTA linking to `/the-2025-challenge` |
+| Video | `<nc-base-section>` | YouTube embed + "The Challenge" text |
+| CTA (FAQ + Webinar) | `<nc-cta>` | Two-panel CTA card |
+| Blog | `<nc-blog-section>` | Latest 3 blog posts |
+
+### Changes
+
+#### 1.1 Hero — Replace with Incubator intro
+
+- **Keep:** `<nc-hero>` wrapper, `hero__content` layout, hero image + animated `<nc-minimal-logo>`.
+- **Replace:** `<h1>` and `<p>` inside `.panel` with Incubator-era placeholder copy.
+  ```
+  h1: "New Commons Incubator"
+  p:  "[PLACEHOLDER] The New Commons Incubator supports teams building data commons..."
+  ```
+- **Remove:** The commented-out "Join the Challenge Today" button.
+- **Add:** A new CTA button: "Apply to the Incubator" linking to `/incubator/2026` (or an external application form URL TBD).
+
+#### 1.2 Announcement bar — Replace with Incubator application CTA
+
+- **Replace** the "Meet the Awardees" announcement with an Incubator application CTA:
+  ```
+  h3: "Now Accepting Applications"
+  h2: "2026 Incubator Cohort"
+  p:  "[PLACEHOLDER] Apply by [DATE TBD] to join the next cohort..."
+  Button: "Apply Now" -> /incubator/2026
+  ```
+- **Add** a secondary link: "View the 2025 Challenge" -> `/the-2025-challenge` (text link, not button). This satisfies the requirement to "add link to the 2025 Challenge archive page."
+
+#### 1.3 Video section — Keep embed, update text
+
+- **Keep:** The `<iframe>` YouTube embed and its container.
+- **Replace** heading and description text:
+  ```
+  h2: "About the Incubator"
+  p:  "[PLACEHOLDER] Learn how the New Commons Incubator helps teams build sustainable data commons..."
+  ```
+- **Decision for implementer:** Confirm whether the same YouTube video URL stays or a new one will be provided. For now, keep the existing embed.
+
+#### 1.4 CTA section — Update FAQ panel + Webinar panel
+
+- **FAQ panel (panel-header):**
+  - Update text to reference Incubator FAQ:
+    ```
+    "Have questions about the Incubator?"
+    ```
+  - Keep the link to `/faq`.
+- **Webinar panel (panel-footer):**
+  - Replace Challenge webinar text with Incubator webinar placeholder:
+    ```
+    h2: "Watch the Incubator Info Session"
+    p:  "[PLACEHOLDER] Missed the live session? Watch our webinar to learn about the 2026 Incubator..."
+    ```
+  - Keep the "Watch now!" button pointing to `#video`.
+
+#### 1.5 Blog section — No changes
+
+- Keep `<nc-blog-section>` as-is.
+
+### File-level notes
+
+- No new components needed. All changes are content swaps inside existing markup.
+- The `<script setup>` block stays the same (blogposts query).
+- No style changes required.
+
+---
+
+## 2. Incubator Page (`pages/incubator/2026.vue`)
+
+### Current State
+
+This page was created by CCM-105 as a copy of the old prize page with a placeholder banner. It currently contains:
+- A placeholder banner ("Coming Soon...")
+- Old prize hero with Challenge-era copy
+- "What are we looking for?" cards (Localized Decision-making / Humanitarian Interventions)
+- Prizes section with dollar amounts and support details
+- "Who can apply?" / Eligibility section
+- Helpful Tips section
+- Judges and Observers grids
+
+### Target Structure
+
+Replace everything above the judges grid with proper Incubator content. The page should have these sections in order:
+
+#### 2.1 Hero
+
+- **Remove** the placeholder banner (`<nc-base-section class="placeholder-banner">`).
+- **Replace** hero content:
+  ```
+  Brow:  "2026 Cohort"
+  h1:    "The New Commons Incubator"
+  p:     "[PLACEHOLDER] The New Commons Incubator is a 12-month programme that provides..."
+  ```
+- **Keep** the announcement bar linking to the 2025 Challenge (already present, just update copy if needed).
+
+#### 2.2 Program Overview section (NEW)
+
+- Use `<nc-base-section>` with a simple two-column layout (text + optional image or icon).
+- Content structure:
+  ```html
+  <h2>Program Overview</h2>
+  <p>[PLACEHOLDER] The Incubator provides selected teams with funding, mentorship,
+     and technical resources to build or enhance data commons for responsible AI...</p>
+  ```
+- Can reuse the existing `.switcher` layout pattern.
+
+#### 2.3 "What We Offer" section (REPLACES old "What are we looking for?" + Prizes)
+
+- Use the existing two-card layout (`.prize-card` pattern) but rename the CSS class to something like `.offer-card`.
+- Cards (3-4 items, using icon + title + description pattern already in use):
+  ```
+  Card 1: Funding — "[PLACEHOLDER] Up to $X in grant funding..."
+  Card 2: Mentorship & Guidance — "[PLACEHOLDER] Access to experts in data governance..."
+  Card 3: Technical Support — "[PLACEHOLDER] Hands-on technical assistance..."
+  Card 4: Network Access — "[PLACEHOLDER] Connect with the Open Data Policy Lab's global network..."
+  ```
+- **Implementation note:** The existing `.prize-card` grid layout works well. Reuse the icon assets (`/assets/trophy.svg`, `/assets/mentorship.svg`, `/assets/support.svg`, `/assets/globe.svg`) — they are generic enough.
+
+#### 2.4 "Who Should Apply" section (REPLACES old eligibility)
+
+- Use `<nc-base-section color="faded">`.
+- Structure:
+  ```html
+  <h2>Who Should Apply</h2>
+  <p>[PLACEHOLDER] We welcome applications from nonprofits, academic institutions,
+     startups, and development organisations working with data commons...</p>
+  <h3>Eligibility Criteria</h3>
+  <ul>
+    <li>[PLACEHOLDER] Must be affiliated with an established organisation...</li>
+    <li>[PLACEHOLDER] Project must focus on data commons for AI...</li>
+    <li>[PLACEHOLDER] Must demonstrate capacity to implement over 12 months...</li>
+  </ul>
+  ```
+
+#### 2.5 Timeline section
+
+- **Option A (recommended):** Reuse the existing `<nc-timeline>` component. It is already built and supports a card-based visual timeline. Update the data array in the component or pass timeline data as props.
+  - The current `ncTimeline.vue` has hardcoded Challenge dates. For the Incubator, either:
+    - (a) Make the component accept a `timeline` prop (preferred — keeps it reusable), or
+    - (b) Create a new inline timeline in the page using the same CSS pattern.
+- **Option B (simpler):** Build a simple inline ordered list styled as a vertical timeline. Less visual but faster to implement.
+- **Recommended approach:** Option A — refactor `<nc-timeline>` to accept a `timeline` prop with a default fallback. Then use it in the Incubator page:
+  ```html
+  <nc-timeline :timeline="incubatorTimeline" />
+  ```
+  ```js
+  const incubatorTimeline = [
+    { date: '2026-03-01T00:00:00Z', event: '[PLACEHOLDER] Applications open' },
+    { date: '2026-05-01T00:00:00Z', event: '[PLACEHOLDER] Applications close' },
+    { date: '2026-06-15T00:00:00Z', event: '[PLACEHOLDER] Cohort announced' },
+    { date: '2026-09-01T00:00:00Z', event: '[PLACEHOLDER] Programme begins' },
+  ]
+  ```
+
+#### 2.6 Application CTA section
+
+- Use the existing CTA panel pattern (dark background + button).
+- Content:
+  ```html
+  <h2>Ready to Apply?</h2>
+  <p>[PLACEHOLDER] Submit your application by [DATE TBD]...</p>
+  <nc-button color="primary" variant="primary">Apply Now</nc-button>
+  ```
+- The button href is TBD (external Google Form or built-in form).
+
+#### 2.7 Judges & Observers — KEEP
+
+- Keep `<nc-judges-grid />` and `<nc-observers-grid />` exactly as they are.
+- These components pull their own data and need no changes.
+
+### Sections to REMOVE
+
+- The old "Prizes" section (two winners, USD 100k, etc.)
+- The old "Helpful Tips" section (Blueprint, Inspirational Examples)
+- The `placeholder-banner` at the top
+
+### Script changes
+
+- Remove `const { rulesUrl } = useSiteLinks()` if the Rules link is no longer needed on this page.
+- Add `incubatorTimeline` data (if using Option A for timeline).
+
+### Style changes
+
+- Rename `.prize-card` to `.offer-card` (or keep the class name and just change content — implementer's call on cleanliness).
+- Remove `.prize-cta`, `.prize-list`, `.prize-tips` styles that are no longer used.
+- Add any new styles for the timeline if building inline.
+
+---
+
+## 3. FAQ Content Swap (`pages/faq.vue`)
+
+### Current Structure
+
+The FAQ page uses `<nc-faq-section>` wrappers with `<nc-collapse>` accordion items. FAQ data is defined inline in `<script setup>` as a `faq` object with these category keys:
+
+| Key | Current Category |
+|-----|-----------------|
+| `information` | Challenge Information |
+| `eligibility` | Eligibility and Institutional Affiliation |
+| `application` | Application Process |
+| `scope` | Project Scope and Partnerships |
+| `criteria` | Proposal Evaluation Criteria |
+| `decision` | Localized Decision-Making |
+| `support` | Support and Technical Capacity |
+| `timeline` | Challenge Timeline and Submission Details |
+
+### New Category Structure
+
+Replace all 8 categories with Incubator-relevant categories. Suggested grouping:
+
+| Key | New Category | Description |
+|-----|-------------|-------------|
+| `program` | About the Incubator | What is it, who runs it, what do participants receive |
+| `eligibility` | Eligibility | Who can apply, geographic restrictions, org types |
+| `application` | Application Process | How to apply, deadlines, what to submit |
+| `support` | Support & Resources | What support is provided, mentorship, technical help |
+| `timeline` | Timeline & Key Dates | When things happen |
+| `governance` | Data Governance | How data commons should be governed, requirements |
+
+### Implementation
+
+1. **Keep the template structure exactly as-is** — just update `v-for` bindings if category keys change, and update the `<h3>` headings.
+2. **Replace the `faq` object** in `<script setup>` with new placeholder Q&A pairs.
+3. Each Q&A item follows the existing shape: `{ summary: string, content: string }`.
+4. Prefix all answer content with `<!-- TODO(CCM-108): Replace with client copy -->`.
+5. Write 2-4 placeholder questions per category (matching realistic Incubator topics).
+
+### Example placeholder items
+
+```js
+program: [
+  {
+    summary: 'What is the New Commons Incubator?',
+    content: `
+      <!-- TODO(CCM-108): Replace with client copy — program description -->
+      <p>[PLACEHOLDER] The New Commons Incubator is a programme run by the Open Data Policy Lab
+         that supports teams in building and sustaining data commons for responsible AI development...</p>
+    `
+  },
+  {
+    summary: 'What do Incubator participants receive?',
+    content: `
+      <!-- TODO(CCM-108): Replace with client copy — participant benefits -->
+      <p>[PLACEHOLDER] Participants receive funding, mentorship, technical support,
+         and access to the Open Data Policy Lab's global network of experts...</p>
+    `
+  },
+]
+```
+
+### Style changes
+
+- None. Keep existing styles as-is.
+
+---
+
+## 4. Implementation Order
+
+Recommended sequence:
+
+1. **FAQ page** (simplest — pure data swap, no layout changes)
+2. **Homepage** (content swaps in existing layout, no structural changes)
+3. **Incubator page** (most work — removing old sections, building new ones, potential timeline component refactor)
+
+---
+
+## 5. Testing Checklist
+
+- [ ] All three pages render without errors
+- [ ] No references to "Challenge" remain in Incubator-era content (except the 2025 Challenge archive link)
+- [ ] Every `[PLACEHOLDER]` text is accompanied by a `<!-- TODO(CCM-108) -->` comment
+- [ ] Navigation links in `ncTopbar.vue` still work (no route changes needed — "The Incubator" already points to `/incubator/2026`)
+- [ ] YouTube embed still plays on homepage
+- [ ] Judges and Observers grids render on Incubator page
+- [ ] FAQ accordions open/close correctly with new content
+- [ ] Page looks reasonable on mobile (no layout regressions)
+- [ ] `grep -r "TODO(CCM-108)"` returns all placeholder locations for easy audit
+
+---
+
+## 6. Open Questions for Implementer
+
+1. **Timeline component:** Should `<nc-timeline>` be refactored to accept props (reusable) or should a new inline timeline be built in the Incubator page? Recommendation: refactor to accept props.
+2. **YouTube video:** Does the same video stay on the homepage, or will a new Incubator-specific video be provided? Keep current embed for now.
+3. **Application CTA destination:** Where does "Apply Now" link to? An external Google Form (like the Challenge used), or a new page? Use `#` as href placeholder until confirmed.
+4. **Offer amounts:** The old page showed "USD 100,000" grants. The Incubator funding structure may differ. Use generic "[PLACEHOLDER] Up to $X" until confirmed.
+5. **Rules link:** The topbar still has a "Rules" link (`useSiteLinks().rulesUrl`). Does this need updating for the Incubator, or does it stay as the Challenge rules? Leave as-is for now — this is outside CCM-108 scope.
+6. **"Helpful Tips" content:** The old prize page had Blueprint and Inspirational Examples links. Should any of this content carry over to the Incubator page, perhaps in a "Resources" subsection? Assume no unless client requests it.

--- a/pages/faq.vue
+++ b/pages/faq.vue
@@ -32,19 +32,19 @@
 <script setup>
 const faq = {
   program: [
+    // TODO(CCM-108): Replace with client copy — program description
     {
       summary: 'What is the New Commons Incubator?',
       content: `
-        <!-- TODO(CCM-108): Replace with client copy — program description -->
         <p>[PLACEHOLDER] The New Commons Incubator is a 12-month programme run by the Open Data Policy Lab
            that supports teams in building and sustaining data commons for responsible AI development.
            It builds on the success of the New Commons Challenge by providing deeper, hands-on support.</p>
       `
     },
+    // TODO(CCM-108): Replace with client copy — participant benefits
     {
       summary: 'What do Incubator participants receive?',
       content: `
-        <!-- TODO(CCM-108): Replace with client copy — participant benefits -->
         <p>[PLACEHOLDER] Each selected team receives:</p>
         <ul>
           <li>Grant funding (amount TBD)</li>
@@ -54,19 +54,19 @@ const faq = {
         </ul>
       `
     },
+    // TODO(CCM-108): Replace with client copy — organisers
     {
       summary: 'Who runs the Incubator?',
       content: `
-        <!-- TODO(CCM-108): Replace with client copy — organisers -->
         <p>[PLACEHOLDER] The New Commons Incubator is an initiative of the
            <a href="https://opendatapolicylab.org/" target="_blank" rel="noopener">Open Data Policy Lab</a>,
            a collaboration between The GovLab at New York University and Microsoft.</p>
       `
     },
+    // TODO(CCM-108): Replace with client copy — challenge vs incubator
     {
       summary: 'How is the Incubator different from the Challenge?',
       content: `
-        <!-- TODO(CCM-108): Replace with client copy — challenge vs incubator -->
         <p>[PLACEHOLDER] While the Challenge was a competitive prize programme that selected two winners,
            the Incubator takes a cohort-based approach, providing sustained support over 12 months to
            multiple teams working on data commons for responsible AI.</p>
@@ -74,55 +74,55 @@ const faq = {
     },
   ],
   eligibility: [
+    // TODO(CCM-108): Replace with client copy — eligibility overview
     {
       summary: 'Who can apply to the Incubator?',
       content: `
-        <!-- TODO(CCM-108): Replace with client copy — eligibility overview -->
         <p>[PLACEHOLDER] We welcome applications from nonprofits, academic institutions, startups,
            and development organisations working with data commons. Applicants must be affiliated
            with an established institution capable of managing funds.</p>
       `
     },
+    // TODO(CCM-108): Replace with client copy — geographic eligibility
     {
       summary: 'Are there geographic restrictions?',
       content: `
-        <!-- TODO(CCM-108): Replace with client copy — geographic eligibility -->
         <p>[PLACEHOLDER] The Incubator is a global programme. We welcome applications from
            organisations worldwide, though we may be unable to deliver support to entities
            subject to sanctions under U.S. law.</p>
       `
     },
+    // TODO(CCM-108): Replace with client copy — government eligibility
     {
       summary: 'Can government agencies apply?',
       content: `
-        <!-- TODO(CCM-108): Replace with client copy — government eligibility -->
         <p>[PLACEHOLDER] Government entities may not apply as lead applicants but may participate
            as collaborators or partners on a project.</p>
       `
     },
   ],
   application: [
+    // TODO(CCM-108): Replace with client copy — application process
     {
       summary: 'How do I apply?',
       content: `
-        <!-- TODO(CCM-108): Replace with client copy — application process -->
         <p>[PLACEHOLDER] Applications are submitted through our online form. You will need to
            provide information about your organisation, your proposed data commons project,
            and a letter of institutional support.</p>
       `
     },
+    // TODO(CCM-108): Replace with client copy — deadline
     {
       summary: 'What is the application deadline?',
       content: `
-        <!-- TODO(CCM-108): Replace with client copy — deadline -->
         <p>[PLACEHOLDER] The application deadline is [DATE TBD]. Late applications will not
            be considered.</p>
       `
     },
+    // TODO(CCM-108): Replace with client copy — multiple applications
     {
       summary: 'Can my organisation submit multiple applications?',
       content: `
-        <!-- TODO(CCM-108): Replace with client copy — multiple applications -->
         <p>[PLACEHOLDER] Each organisation may submit one application. If you need to revise
            a submission, contact us at
            <a href="mailto:newcommons@opendatapolicylab.org">newcommons@opendatapolicylab.org</a>.</p>
@@ -130,19 +130,19 @@ const faq = {
     },
   ],
   support: [
+    // TODO(CCM-108): Replace with client copy — mentorship details
     {
       summary: 'What kind of mentorship is provided?',
       content: `
-        <!-- TODO(CCM-108): Replace with client copy — mentorship details -->
         <p>[PLACEHOLDER] Selected teams are paired with mentors from the Open Data Policy Lab
            network who have expertise in data governance, AI ethics, and commons management.
            Mentorship sessions are held regularly throughout the 12-month programme.</p>
       `
     },
+    // TODO(CCM-108): Replace with client copy — technical support
     {
       summary: 'What technical support is available?',
       content: `
-        <!-- TODO(CCM-108): Replace with client copy — technical support -->
         <p>[PLACEHOLDER] Teams receive hands-on technical assistance with data infrastructure,
            interoperability standards, and platform development. The specifics are tailored
            to each team's needs and stage of development.</p>
@@ -150,10 +150,10 @@ const faq = {
     },
   ],
   timeline: [
+    // TODO(CCM-108): Replace with client copy — key dates
     {
       summary: 'What are the key dates for the 2026 Incubator?',
       content: `
-        <!-- TODO(CCM-108): Replace with client copy — key dates -->
         <p>[PLACEHOLDER] Key dates:</p>
         <ul>
           <li><strong>[DATE TBD]</strong> — Applications open</li>
@@ -163,10 +163,10 @@ const faq = {
         </ul>
       `
     },
+    // TODO(CCM-108): Replace with client copy — programme duration
     {
       summary: 'How long is the Incubator programme?',
       content: `
-        <!-- TODO(CCM-108): Replace with client copy — programme duration -->
         <p>[PLACEHOLDER] The Incubator runs for approximately 12 months from the programme
            start date. Teams are expected to make significant progress on their data commons
            within this timeframe.</p>
@@ -174,19 +174,19 @@ const faq = {
     },
   ],
   governance: [
+    // TODO(CCM-108): Replace with client copy — governance expectations
     {
       summary: 'What governance structures are expected for data commons?',
       content: `
-        <!-- TODO(CCM-108): Replace with client copy — governance expectations -->
         <p>[PLACEHOLDER] Applicants should articulate how their data commons will be
            responsibly governed, including who will be involved in oversight and strategic
            decisions about data access and use.</p>
       `
     },
+    // TODO(CCM-108): Replace with client copy — governance frameworks
     {
       summary: 'Are there specific data governance frameworks we should follow?',
       content: `
-        <!-- TODO(CCM-108): Replace with client copy — governance frameworks -->
         <p>[PLACEHOLDER] While we do not mandate a specific framework, applicants may find it
            useful to refer to the Open Data Policy Lab's
            <a href="https://incubator.opendatapolicylab.org/files/data-commons-for-ai-blueprint.pdf" target="_blank" rel="noopener">

--- a/pages/faq.vue
+++ b/pages/faq.vue
@@ -4,361 +4,197 @@
   </nc-base-section>
 
   <nc-faq-section background-color="transparent">
-    <h3 class="h3">Challenge Information</h3>
-    <nc-collapse name="challenge" v-for="item in faq.information" :key="item.summary" :data="item" />          
+    <h3 class="h3">About the Incubator</h3>
+    <nc-collapse name="program" v-for="item in faq.program" :key="item.summary" :data="item" />
   </nc-faq-section>
   <nc-faq-section>
-    <h3 class="h3">Eligibility and Institutional Affiliation</h3>
-    <nc-collapse name="eligibility" v-for="item in faq.eligibility" :key="item.summary" :data="item" />          
+    <h3 class="h3">Eligibility</h3>
+    <nc-collapse name="eligibility" v-for="item in faq.eligibility" :key="item.summary" :data="item" />
   </nc-faq-section>
-  <nc-faq-section >
+  <nc-faq-section>
     <h3 class="h3">Application Process</h3>
-    <nc-collapse name="application" v-for="item in faq.application" :key="item.summary" :data="item" />          
+    <nc-collapse name="application" v-for="item in faq.application" :key="item.summary" :data="item" />
   </nc-faq-section>
-  <nc-faq-section >
-    <h3 class="h3">Project Scope and Partnerships</h3>
-    <nc-collapse name="project" v-for="item in faq.scope" :key="item.summary" :data="item" />          
+  <nc-faq-section>
+    <h3 class="h3">Support &amp; Resources</h3>
+    <nc-collapse name="support" v-for="item in faq.support" :key="item.summary" :data="item" />
   </nc-faq-section>
-  <nc-faq-section >
-    <h3 class="h3">Proposal Evaluation Criteria</h3>
-    <nc-collapse name="proposal" v-for="item in faq.criteria" :key="item.summary" :data="item" />          
-  </nc-faq-section>
-  <nc-faq-section >
-    <h3 class="h3">Localized Decision-Making</h3>
-    <nc-collapse name="localized" v-for="item in faq.decision" :key="item.summary" :data="item" />          
-  </nc-faq-section>
-  <nc-faq-section >
-    <h3 class="h3">Support and Technical Capacity</h3>
-    <nc-collapse name="support" v-for="item in faq.support" :key="item.summary" :data="item" />          
+  <nc-faq-section>
+    <h3 class="h3">Timeline &amp; Key Dates</h3>
+    <nc-collapse name="timeline" v-for="item in faq.timeline" :key="item.summary" :data="item" />
   </nc-faq-section>
   <nc-faq-section class="last-item">
-    <h3 class="h3">Challenge Timeline and Submission Details</h3>
-    <nc-collapse name="timeline" v-for="item in faq.timeline" :key="item.summary" :data="item" />       
+    <h3 class="h3">Data Governance</h3>
+    <nc-collapse name="governance" v-for="item in faq.governance" :key="item.summary" :data="item" />
   </nc-faq-section>
 </template>
 
 <script setup>
 const faq = {
-  information: [
+  program: [
     {
-      summary: 'What is the focus of this Challenge?',
+      summary: 'What is the New Commons Incubator?',
       content: `
-        <p>As noted on our website, the New Commons Challenge seeks to address emerging questions around the development of artificial intelligence. While AI is celebrated as the defining technology of our time, the data needed to build these systems responsibly and effectively is increasingly out of reach.</p>
-        <p>Building on the Open Data Policy Lab’s research on “<a href="https://opendatapolicylab.org/articles/blog-post-the-emergent-landscape-of-data-commons-a-brief-survey-and-comparison-of-existing-initiatives/" target="_blank" rel="noopener">data commons</a>”—shared pools of data resources that are managed using participatory approaches—we seek to fill this gap and support the development of AI systems that align with public needs and expectations. We seek to do this in the domains of humanitarian response and localized decisionmaking, two areas where additional resources are urgently needed.</p>
-      `,
+        <!-- TODO(CCM-108): Replace with client copy — program description -->
+        <p>[PLACEHOLDER] The New Commons Incubator is a 12-month programme run by the Open Data Policy Lab
+           that supports teams in building and sustaining data commons for responsible AI development.
+           It builds on the success of the New Commons Challenge by providing deeper, hands-on support.</p>
+      `
     },
     {
-      summary: 'What is the Open Data Policy Lab?',
+      summary: 'What do Incubator participants receive?',
       content: `
-        <p><a href="https://opendatapolicylab.org/" target="_blank" rel="noopener">The Open Data Policy Lab</a> is a collaboration between The GovLab at New York University and Microsoft. It supports decision-makers at the local, state and national levels as they accelerate the responsible re-use and opening of data for the benefit of society and the equitable spread of economic opportunity.</p>
-      `,
-    },
-    {
-      summary: 'What will awardees receive?',
-      content: `
-        <p>This challenge will distribute two grant awards:</p>
+        <!-- TODO(CCM-108): Replace with client copy — participant benefits -->
+        <p>[PLACEHOLDER] Each selected team receives:</p>
         <ul>
-          <li><strong>Award 1:</strong> Development of a Data Commons: $100,000 will be awarded to one applicant who seeks to develop a new data commons to support responsible AI development for humanitarian response and/or localized decisionmaking</li>
-          <li><strong>Award 2:</strong> Enhancement of a Data Commons: $100,000 will be awarded to one applicant who seeks to strengthen an existing data commons to support responsible AI development for humanitarian response and/or localized decisionmaking.</li>
+          <li>Grant funding (amount TBD)</li>
+          <li>Mentorship from experts in data governance and AI ethics</li>
+          <li>Technical support for data infrastructure and platform development</li>
+          <li>Access to the Open Data Policy Lab's global network</li>
         </ul>
-        <p>Both prize winners will receive additional technical support and access to the Open Data Policy Lab’s network of experts.</p>
-      `,
+      `
     },
     {
-      summary: 'What makes a strong submission?',
+      summary: 'Who runs the Incubator?',
       content: `
-        <p>We welcome initiatives that expand access to diverse data sources, including text, video, images, audio, and synthetic data as outlined in the Open Data Policy Lab’s <a href="https://incubator.opendatapolicylab.org/files/data-commons-for-ai-blueprint.pdf" target="_blank" rel="noopener">A Blueprint to Unlock New Data Commons for AI</a>.</p>
-        <p>Applicants may find inspirational examples of what to submit in our list of instructive examples <a href="https://docs.google.com/spreadsheets/d/1GPzU4Pspi-XOmJU13LvOUUPxtfTuRXcZMBw7lxkQRyY/edit?gid=0#gid=0" target="_blank" rel="noopener">here</a>.</p>
-      `,
-    }
+        <!-- TODO(CCM-108): Replace with client copy — organisers -->
+        <p>[PLACEHOLDER] The New Commons Incubator is an initiative of the
+           <a href="https://opendatapolicylab.org/" target="_blank" rel="noopener">Open Data Policy Lab</a>,
+           a collaboration between The GovLab at New York University and Microsoft.</p>
+      `
+    },
+    {
+      summary: 'How is the Incubator different from the Challenge?',
+      content: `
+        <!-- TODO(CCM-108): Replace with client copy — challenge vs incubator -->
+        <p>[PLACEHOLDER] While the Challenge was a competitive prize programme that selected two winners,
+           the Incubator takes a cohort-based approach, providing sustained support over 12 months to
+           multiple teams working on data commons for responsible AI.</p>
+      `
+    },
   ],
   eligibility: [
     {
-      summary: 'Are there any geographic restrictions?',
+      summary: 'Who can apply to the Incubator?',
       content: `
-        <p>The New Commons Challenge is a global innovation challenge that welcomes entries from organizations across continents. We hope to receive applicants from diverse regions and contexts.</p>
-        <p>We welcome any entry, though we may be unable to deliver prizes to certain entities and individuals who are subject to sanctions and other restrictions under U.S. law, such as those based in 
-          <a href="https://ofac.treasury.gov/sanctions-programs-and-country-information/cuba-sanctions" target="_blank" rel="noopener">Cuba</a>, 
-          <a href="https://ofac.treasury.gov/sanctions-programs-and-country-information/iran-sanctions" target="_blank" rel="noopener">Iran</a>, 
-          <a href="https://ofac.treasury.gov/sanctions-programs-and-country-information/north-korea-sanctions" target="_blank" rel="noopener">North Korea</a>, 
-          <a href="https://home.treasury.gov/policy-issues/financial-sanctions/sanctions-programs-and-country-information/ukraine-russia-related-sanctions" target="_blank" rel="noopener">Russia</a>, 
-          <a href="https://ofac.treasury.gov/sanctions-programs-and-country-information/syria-sanctions" target="_blank" rel="noopener">Syria</a>, and the 
-          <a href="https://home.treasury.gov/policy-issues/financial-sanctions/sanctions-programs-and-country-information/ukraine-russia-related-sanctions" target="_blank" rel="noopener">Crimea, Donestsk, and Luhansk regions of Ukraine</a>.
-        </p>
-      `,
+        <!-- TODO(CCM-108): Replace with client copy — eligibility overview -->
+        <p>[PLACEHOLDER] We welcome applications from nonprofits, academic institutions, startups,
+           and development organisations working with data commons. Applicants must be affiliated
+           with an established institution capable of managing funds.</p>
+      `
     },
     {
-      summary: 'Can my organization submit an application in a language other than English?',
+      summary: 'Are there geographic restrictions?',
       content: `
-        <p>While we welcome entries from a variety of applicants, we are unfortunately only able to review applications in English. You may use translation services (e.g. Google Translate) to help you submit your application if need be.</p>
-      `,
+        <!-- TODO(CCM-108): Replace with client copy — geographic eligibility -->
+        <p>[PLACEHOLDER] The Incubator is a global programme. We welcome applications from
+           organisations worldwide, though we may be unable to deliver support to entities
+           subject to sanctions under U.S. law.</p>
+      `
     },
     {
-      summary: 'What if my organization is not incorporated as a nonprofit? Am I eligible?',
+      summary: 'Can government agencies apply?',
       content: `
-        <p>We feel this challenge may be most applicable to nonprofit organizations, academic institutions, start-ups, and development organizations. If applicants are asked to submit a full proposal, they may be asked to provide information about their tax status.</p>
-        <p>For-profit entities submitting proposals may be asked to undergo extra review to ensure their proposal aids the public on an issue related to humanitarian response and/or localized decision-making. Government entities may not apply.</p>
-      `,
-    },
-    {
-      summary: 'Can my organization work with another organization to submit a proposal?',
-      content: `
-        <p>While you may submit a proposal in coordination with another organization, we will distribute funds to only the lead organizer’s institution. It will be the responsibility of the team to appropriately distribute funds.</p>
-      `,
-    },
-    {
-      summary: 'What do you mean by “being affiliated with an established organization”?',
-      content: `
-        <p>Applicants must be affiliated with an established institution capable of managing funds and supporting project execution. A letter of institutional support is required to confirm this affiliation. We do not fund individuals directly.</p>
-      `,
-    },
-    {
-      summary: 'If a project has support from high-profile funders, does that affect eligibility? Is there a minimum organization size?',
-      content: `
-        <p>No. Prior funding or organization size does not affect eligibility. We focus on whether the applicant has the capacity to complete the proposed work.</p>
-      `,
+        <!-- TODO(CCM-108): Replace with client copy — government eligibility -->
+        <p>[PLACEHOLDER] Government entities may not apply as lead applicants but may participate
+           as collaborators or partners on a project.</p>
+      `
     },
   ],
   application: [
     {
-      summary: 'What is the application process for the New Commons Challenge?',
+      summary: 'How do I apply?',
       content: `
-        <p>The New Commons Challenge takes place over two phases.</p>
-        <ul>
-          <li><strong>Phase 1:</strong> Applicants will be asked to fill out a form providing basic information of the opportunity they hope to address, the data they intend to use to address that opportunity, the relevance to humanitarian response and/or localized decisionmaking; and how the project will be commonly governed. These submissions—”concept notes”—will be reviewed by the Open Data Policy Lab team, with compelling applications referred to Phase 2.</li>
-          <li><strong>Phase 2:</strong> Applicants will be asked to submit a full proposal outlining their approach, including the ways that their proposed work innovates, its feasibility, its impact, and the delivery team. These proposals will be reviewed and evaluated by an expert jury. Details on format of proposals will be provided to applicants when referred.</li>
-        </ul>
-      `,
+        <!-- TODO(CCM-108): Replace with client copy — application process -->
+        <p>[PLACEHOLDER] Applications are submitted through our online form. You will need to
+           provide information about your organisation, your proposed data commons project,
+           and a letter of institutional support.</p>
+      `
     },
     {
-      summary: 'What will be required to submit for the full proposal?',
+      summary: 'What is the application deadline?',
       content: `
-        <p>Details on the requirements of the full proposal be provided to applicants at the start of the second phase via email. If you did not receive these requirements, please message us at <a href="mailto:newcommons@opendatapolicylab.org" target="_blank" rel="noopener">newcommons@opendatapolicylab.org</a>.</p>
-      `,
+        <!-- TODO(CCM-108): Replace with client copy — deadline -->
+        <p>[PLACEHOLDER] The application deadline is [DATE TBD]. Late applications will not
+           be considered.</p>
+      `
     },
     {
-      summary: 'What are the key deadlines and program milestones for the New Commons Challenge?',
+      summary: 'Can my organisation submit multiple applications?',
       content: `
-        <p>The Challenge will follow the schedule outlined below:</p>
-        <p><strong>Monday, April 14, 2025</strong></p>
-        <ul><li>1st Phase: Concept note submission opens</li></ul>
-        <p><strong>Monday, June 10, 2025</strong></p>
-        <ul><li>Concept note submission closes</li></ul>
-        <p><strong>Monday, June 16, 2025</strong></p>
-        <ul>
-          <li>Applicants who are invited to submit full proposals are notified</li>
-          <li>2nd Phase: full proposal submission opens</li>
-        </ul>
-        <p><strong>Monday, July 14, 2025</strong></p>
-        <ul><li>Full proposal submission closes</li></ul>
-        <p><strong>August – November 2025</strong></p>
-        <ul>
-          <li>Judging phase</li>
-          <li>Winners notified & announced</li>
-          <li>Implementation and Support Phase</li>
-        </ul>
-      `,
-    },
-    {
-      summary: 'Can my organization submit multiple applications?',
-      content: `
-        <p>No, your organization may only submit one application for evaluation. If you mistakenly submitted an application early and need to delete your submission before submitting a revision, please contact us at <a href="mailto:newcommons@opendatapolicylab.org" target="_blank" rel="noopener">newcommons@opendatapolicylab.org</a>.</p>
-      `,
-    },
-    {
-      summary: 'What if I am unable to submit or access the form?',
-      content: `
-        <p>To facilitate this Challenge, we rely on the Google Form here. If, for any reason, you are unable to submit the form, you may download a text version of the form <a href="https://docs.google.com/document/d/1KedF0ozxqt-YzsK4QC87YxHTTQKw5gLtpP40liEiZVY/edit?usp=sharing" target="_blank" rel="noopener">here</a> and submit your responses to the questions as a Word doc or PDF file to <a href="mailto:newcommons@opendatapolicylab.org" target="_blank" rel="noopener">newcommons@opendatapolicylab.org</a>.</p>
-      `,
-    },
-    {
-      summary: 'What is a “letter of support”?',
-      content: `
-        <p>A letter of support is any letter, on institutional letterhead, from a representative of an institution indicating that they are aware of the proposal and their institution will support it if funded. It is our way of ensuring that any project funded can sustain itself beyond the initial $100,000.</p>
-      `,
-    },
-    {
-      summary: 'How will I be informed about any decision regarding my submitted concept note?',
-      content: `
-        <p>All applicants will be notified via email of whether they will be invited to submit to the second phase by the week of June 16, 2025. All decisions made by the Open Data Policy Lab team are final.</p>
-      `,
-    },
-  ],
-  scope: [
-    {
-      summary: 'Can local government agencies participate as collaborators, but not as lead applicants? Are there limitations on resource sharing?',
-      content: `
-        <p>Yes. Governments may be partners but not lead applicants. If resource sharing is involved, it will be reviewed to ensure Challenge funds are not directed primarily to government entities.</p>
-      `,
-    },
-    {
-      summary: 'Can a proposal focus on strengthening community-led organizations?',
-      content: `
-        <p>Yes, if the work includes the creation or enhancement of a data commons for AI.</p>
-      `,
-    },
-    {
-      summary: 'Do you help applicants find partners?',
-      content: `
-        <p>We do not facilitate formal matchmaking. Applicants are encouraged to build partnerships independently.</p>
-      `,
-    },
-  ],
-  criteria: [
-    {
-      summary: 'What is the “opportunity” criterion evaluating?',
-      content: `
-        <p>This criterion looks at:</p>
-        <ul>
-          <li>The relevance and urgency of the problem addressed</li>
-          <li>The creativity and novelty of the approach</li>
-          <li>Alignment with Challenge Blueprint methodologies or data types</li>
-          <li>Potential for scalability or broader impact</li>
-        </ul>
-      `,
-    },
-    {
-      summary: 'Are there restrictions on political applications of projects (e.g. advocacy)?',
-      content: `
-        <p>We do not fund partisan political work. Projects with policy implications are eligible, as long as they serve public interest objectives and are not aligned with a specific political agenda.</p>
-      `,
-    },
-    {
-      summary: 'How will my application be evaluated?',
-      content: `
-        <p>Each phase of the Challenge will be evaluated according to a preset criteria. For Phase 1, that is:</p>
-        <p><strong>Opportunit: </strong>What’s the opportunity</p>
-        <ul>
-          <li>What’s the problem that this proposed work is seeking to address?</li>
-          <li>Does it suggest any creative or unconventional approaches for addressing the challenge?</li>
-          <li>Does the approach align with one of the approaches or data types outlined in our blueprint?</li>
-        </ul>
-        <p>Weighting: 40%</p>
-        <p><strong>Data: </strong>What's the data the team has access to?</p>
-        <ul>
-          <li>Does the proposal indicate that the team has or is able to responsibly secure access to data?</li>
-          <li>Is the data and its proposed application in any way new or non-traditional?</li>
-          <li>Would the insights provided fill a known gap in the research? </li>
-        </ul>
-        <p>Weighting: 25%</p>
-        <p><strong>Relevance: </strong>How does the proposal support localized decision-making/disaster response?</p>
-        <ul>
-          <li>Does the proposal outline a pathway in which this work would support localized decision-making or disaster response?</li>
-          <li>Does it address an urgent need in the field or further empower any actors?</li>
-        </ul>
-        <p>Weighting: 20%</p>
-        <p><strong>Governance: </strong>How will this effort be commonly governed?</p>
-        <ul>
-          <li>Does the project team articulate how the data commons will be responsibly governed?</li>
-          <li>Who will be involved in overseeing the data commons and making strategic decisions about how it is used?</li>
-        </ul>
-        <p>Weighting: 15%</p>
-        <p>For Phase 2, that is: </p>
-        <p><strong>Innovation</strong></p>
-        <ul>
-          <li>How well does the individual/team articulate the problem that the solution is trying to address? </li>
-          <li>How novel and original is the approach in addressing access to Open Data Commons?</li>
-          <li>Does the proposal introduce creative or unconventional ideas?</li>
-          <li>How well does the proposal demonstrate innovative ways of developing a New Commons to prepare data and/or combine datasets to inform responsible AI development?</li>
-        </ul>
-        <p>Weighting: 30%</p>
-        <p><strong>Impact</strong></p>
-        <ul>
-          <li>Does the proposal solve a pressing challenge or address a substantial opportunity regarding humanitarian response or localized decision-making?</li>
-          <li>How well does the proposal address the ability to generate insights that help to inform the actions of real-world decision makers?</li>
-          <li>How clearly has the individual/team defined the end users and the potential to provide real world benefits for these users?</li>
-        </ul>
-        <p>Weighting: 30%</p>
-        <p><strong>Delivery Team</strong></p>
-        <ul>
-          <li>How does the proposal outline the core team’s capabilities and plan to fill any identified gaps?</li>
-          <li>How does the proposal demonstrate a clear understanding of the skills required to deliver and scale the solution, and the route to attaining the required resources and skills?</li>
-          <li>How does the proposal articulate roles and responsibilities within the internal organization team and the wider delivery team?</li>
-        </ul>
-        <p>Weighting: 10%</p>
-      `,
-    },
-    {
-      summary: 'Who will be evaluating my application?',
-      content: `
-        <p>The first phase of the Challenge will be evaluated by the staff of the <a href="https://opendatapolicylab.org/team/" target="_blank" rel="noopener">Open Data Policy Lab</a>.</p>
-        <p>A list of the judges for the second phase will be published on the New Commons in June 2025. </p>
-      `,
-    },
-    {
-      summary: 'Can I dispute any decision regarding the application evaluation process?',
-      content: `
-        <p>All decisions made as part of the New Commons Challenge are final and may not be disputed.</p>
-      `,
-    },
-  ],
-  decision: [
-    {
-      summary: 'Can you further specify which types of local actors you mean by localized decisions?',
-      content: `
-        <p>“Local” refers to decision-making as close to the community as possible. National or global data used to inform local action qualifies. See our examples for guidance.</p>
-      `,
-    },
-    {
-      summary: 'Does localized decision-making require public input sessions?',
-      content: `
-        <p>No, but public input can be included if it strengthens the project. You are encouraged to outline any community engagement in your governance plan.</p>
-      `,
+        <!-- TODO(CCM-108): Replace with client copy — multiple applications -->
+        <p>[PLACEHOLDER] Each organisation may submit one application. If you need to revise
+           a submission, contact us at
+           <a href="mailto:newcommons@opendatapolicylab.org">newcommons@opendatapolicylab.org</a>.</p>
+      `
     },
   ],
   support: [
     {
-      summary: 'Will winners receive technical assistance for creating/enhancing AI commons?',
+      summary: 'What kind of mentorship is provided?',
       content: `
-        <p>Some support (e.g., on governance) will be available, but applicants are expected to have core capacity to implement the project. You should describe your implementation plan in the proposal.</p>
-      `,
+        <!-- TODO(CCM-108): Replace with client copy — mentorship details -->
+        <p>[PLACEHOLDER] Selected teams are paired with mentors from the Open Data Policy Lab
+           network who have expertise in data governance, AI ethics, and commons management.
+           Mentorship sessions are held regularly throughout the 12-month programme.</p>
+      `
     },
     {
-      summary: 'Are there requirements for third-party audits to ensure governance plans?',
+      summary: 'What technical support is available?',
       content: `
-        <p>No, but applicants may choose to include audits as part of their governance strategy.</p>
-      `,
+        <!-- TODO(CCM-108): Replace with client copy — technical support -->
+        <p>[PLACEHOLDER] Teams receive hands-on technical assistance with data infrastructure,
+           interoperability standards, and platform development. The specifics are tailored
+           to each team's needs and stage of development.</p>
+      `
     },
   ],
   timeline: [
-  {
-    summary: 'When does Phase 1 of the Challenge begin?',
-    content: `
-        <p>Phase 1 (concept note submission) began on <strong>April 14, 2025</strong> and ends <strong>June 10, 2025</strong>.</p>
-        <p>Phase 2 (technical proposal) starts <strong>June 16</strong> and ends <strong>July 14</strong>. Final selection will follow.</p>
-    `,
-  },
-  {
-    summary: 'When is the letter of institutional support due?',
-    content: `
-      <p>It must be included with your concept note by <strong>June 10, 2025</strong>.</p>
-    `,
-  },
-  {
-    summary: 'Where do I submit my proposal?',
-    content: `
-      <p>
-        Via the submission form on the Challenge website (top-right corner) or directly via this 
-        <a href="https://docs.google.com/forms/d/e/1FAIpQLSeXuJ9C5tVuISC6Q6HS8-KE8jho_Xl6wz-FV_no0Yx-oRWkMA/viewform" target="_blank" rel="noopener">
-          link
-        </a>.
-      </p>
-    `,
-  },
-  {
-    summary: 'Is there a deadline by which funded projects must be completed?',
-    content: `
-      <p>
-        We aim for significant progress by <strong>November 2025</strong>, though we recognize some projects may evolve over a longer timeframe.
-      </p>
-    `,
-  },
-]
-
-
-
-
-};
+    {
+      summary: 'What are the key dates for the 2026 Incubator?',
+      content: `
+        <!-- TODO(CCM-108): Replace with client copy — key dates -->
+        <p>[PLACEHOLDER] Key dates:</p>
+        <ul>
+          <li><strong>[DATE TBD]</strong> — Applications open</li>
+          <li><strong>[DATE TBD]</strong> — Applications close</li>
+          <li><strong>[DATE TBD]</strong> — Cohort announced</li>
+          <li><strong>[DATE TBD]</strong> — Programme begins</li>
+        </ul>
+      `
+    },
+    {
+      summary: 'How long is the Incubator programme?',
+      content: `
+        <!-- TODO(CCM-108): Replace with client copy — programme duration -->
+        <p>[PLACEHOLDER] The Incubator runs for approximately 12 months from the programme
+           start date. Teams are expected to make significant progress on their data commons
+           within this timeframe.</p>
+      `
+    },
+  ],
+  governance: [
+    {
+      summary: 'What governance structures are expected for data commons?',
+      content: `
+        <!-- TODO(CCM-108): Replace with client copy — governance expectations -->
+        <p>[PLACEHOLDER] Applicants should articulate how their data commons will be
+           responsibly governed, including who will be involved in oversight and strategic
+           decisions about data access and use.</p>
+      `
+    },
+    {
+      summary: 'Are there specific data governance frameworks we should follow?',
+      content: `
+        <!-- TODO(CCM-108): Replace with client copy — governance frameworks -->
+        <p>[PLACEHOLDER] While we do not mandate a specific framework, applicants may find it
+           useful to refer to the Open Data Policy Lab's
+           <a href="https://incubator.opendatapolicylab.org/files/data-commons-for-ai-blueprint.pdf" target="_blank" rel="noopener">
+           Blueprint to Unlock New Data Commons for AI</a> for guidance on governance approaches.</p>
+      `
+    },
+  ],
+}
 </script>
 
 <style scoped>

--- a/pages/incubator/2026.vue
+++ b/pages/incubator/2026.vue
@@ -1,106 +1,105 @@
 <template>
-  <!-- PLACEHOLDER: This page contains content carried over from the 2025 Challenge prize page.
-       It will be replaced with 2026 Incubator-specific content in CCM-108 (Content Refresh). -->
-  <nc-base-section class="placeholder-banner" color="primary">
-    <p><strong>Coming Soon:</strong> The 2026 Incubator programme details are being finalised. The content below is a placeholder from the previous Challenge cycle.</p>
-  </nc-base-section>
-
   <nc-hero>
     <div class="hero__content">
       <div class="panel">
-        <p class="hero__brow">A Prize for a Shared Digital Future</p>
-        <h1>The Incubator — 2026 Cohort</h1>
-        <p>The New Commons Challenge is an initiative led by Microsoft and the Open Data Policy Lab, in partnership with DirectRelief, the Harvard Institutional Data Initiative, and UNESCO (international observer).</p>
-        <p>The challenge addresses a critical issue: the limited access to diverse and high-quality datasets, which is essential for AI to reach its full potential. By creating and improving data commons, which are collaboratively governed data ecosystems that pool and provide responsible access to diverse, high-quality datasets, the gap in AI development can be filled. The challenge seeks to seed new data commons to ensure that AI benefits all.</p>
+        <!-- TODO(CCM-108): Replace with client copy — incubator hero brow, heading, and description -->
+        <p class="hero__brow">2026 Cohort</p>
+        <h1>The New Commons Incubator</h1>
+        <p>[PLACEHOLDER] The New Commons Incubator is a 12-month programme that provides
+           selected teams with funding, mentorship, and technical resources to build or
+           strengthen data commons for responsible AI development.</p>
       </div>
     </div>
     <nc-announcement color="primary" class="hero__announcement">
-      <div class="switcher" style="">
+      <div class="switcher">
         <div style="flex: 3;">
-            <h2>Learn about the 2025 Challenge winners and honorary distinctions</h2>
-            <p>See the groundbreaking data commons recognised at the 2025 New Commons Showcase.</p>
+          <!-- TODO(CCM-108): Replace with client copy — 2025 challenge archive link text -->
+          <h2>Explore the 2025 New Commons Challenge</h2>
+          <p>[PLACEHOLDER] See the winning data commons and honorary distinctions from the inaugural Challenge.</p>
         </div>
         <nc-button class="hero__announcement-button" to="/the-2025-challenge" color="primary" variant="primary" style="align-self: center;">The 2025 Challenge</nc-button>
       </div>
     </nc-announcement>
   </nc-hero>
 
-  <nc-base-section class="fancy-bg" width="narrow" color="primary">
-    <h2 class="text-align:center padding-block:l white-color h2">What are we looking for?</h2>
+  <!-- TODO(CCM-108): Replace with client copy — program overview -->
+  <nc-base-section>
+    <h2>Program Overview</h2>
     <div class="switcher">
-      <div class="prize-card">
-        <img src="/assets/icon-globe.svg" alt="Improve Localized Decision-making">
-        <h3>Improve Localized Decision-making</h3>
-        <p>Help local leaders make better policy or improve their reasoning capabilities through improved access to or insights from data</p>
+      <div class="stack">
+        <p>[PLACEHOLDER] The New Commons Incubator is a 12-month programme run by the
+           Open Data Policy Lab that helps teams build and sustain data commons for
+           responsible AI development. Each cohort receives tailored support to move
+           from concept to implementation.</p>
+        <p>[PLACEHOLDER] Building on the success of the New Commons Challenge, the Incubator
+           takes a deeper, hands-on approach — working closely with selected teams to
+           address technical, governance, and sustainability challenges.</p>
       </div>
-      <div class="prize-card">
-        <img src="/assets/icon-people.svg" alt="Humanitarian Interventions">
-        <h3>Humanitarian Interventions</h3>
-        <p>Strengthen disaster response capabilities using AI.</p>
-      </div>
-    </div>
-  </nc-base-section>
-
-  <nc-base-section class="prize-cta" id="cta" color="faded">
-    <div class="cta-panel | switcher">
-      <div class="stack" style="--_stack-space: var(--space-2xs)">
-        <h2>Prizes</h2>
-        <p>The New Commons Challenge will select two winning proposals to receive the following support package:</p>
-        <div class="cluster margin-top:auto padding-top:s">
-          <!--<div class="button" color="primary" variant="primary">Apply now</div>-->
-          <a :href="rulesUrl" target="_blank" class="button | color:white-color" color="primary" variant="secondary">View Rules</a>
-        </div>
-      </div>
-      <ul class="prize-list | stack">
-        <li class="prize-item">
-          <img src="/assets/trophy.svg" alt="Two winners">
-          <p><span>Two</span> winners</p>
-        </li>
-        <li class="prize-item">
-          <img src="/assets/money.svg" alt="USD 100,000">
-          <p><span>USD 100,000</span> in funding each</p>
-        </li>
-        <li class="prize-item">
-          <img src="/assets/mentorship.svg" alt="Mentorship">
-          <p>Mentorship on establishing and managing data commons</p>
-        </li>
-        <li class="prize-item">
-          <img src="/assets/support.svg" alt="Technical support">
-          <p>Technical support as needed</p>
-        </li>
-        <li class="prize-item">
-          <img src="/assets/globe.svg" alt="Network">
-          <p>Access to the Open Data Policy Lab's global network of experts</p>
-        </li>
-      </ul>
-    </div>
-
-    <div class="cta-panel | switcher">
       <div>
-        <h2>Who can apply?</h2>
+        <!-- Optional: image or illustration. Could reuse /assets/patterns/hero.jpg or a new asset -->
       </div>
-      <div class="stack" style="--_stack-space: var(--space-2xs)">
-        <h3>Eligibility</h3>
-        <p>We welcome proposals from diverse regions, communities, and organizations working with various data types. Your proposed data commons must aim to serve at least one of our key focus areas (Improve Localized Decision-making or Humanitarian Intervention).</p>
-        <nc-button color="white" variant="link">Read here <nc-arrow-link-up /></nc-button>
-        <h3 class="margin-top:s">Evaluation</h3>
-        <p>Proposals will be reviewed by an international jury of experts from both focus areas.</p>
-        <nc-button color="white" variant="link">Read here <nc-arrow-link-up /></nc-button>
-      </div>
-
     </div>
   </nc-base-section>
 
-  <nc-base-section class="prize-tips" subgrid color="faded">
-    <h2 class="margin-bottom:s">Helpful Tips</h2>
-    <div class="stack">
-      <h3>Our Blueprint</h3>
-      <p>This Challenge aims to implement our recently published Blueprint to Unlock New Data Commons for Artificial Intelligence, which shows how organizations can launch data commons in the public interest. Organizations may find it useful to refer to this report as they develop their concept notes and proposals.</p>
+  <!-- TODO(CCM-108): Replace with client copy — what we offer cards -->
+  <nc-base-section class="fancy-bg" color="primary">
+    <h2 class="text-align:center padding-block:l white-color h2">What We Offer</h2>
+    <div class="offer-cards">
+      <div class="offer-card">
+        <img src="/assets/money.svg" alt="Funding">
+        <h3>Funding</h3>
+        <p>[PLACEHOLDER] Up to $X in grant funding to support the development or enhancement of your data commons over 12 months.</p>
+      </div>
+      <div class="offer-card">
+        <img src="/assets/mentorship.svg" alt="Mentorship">
+        <h3>Mentorship &amp; Guidance</h3>
+        <p>[PLACEHOLDER] Regular access to experts in data governance, AI ethics, and commons management from the Open Data Policy Lab network.</p>
+      </div>
+      <div class="offer-card">
+        <img src="/assets/support.svg" alt="Technical Support">
+        <h3>Technical Support</h3>
+        <p>[PLACEHOLDER] Hands-on technical assistance with data infrastructure, interoperability standards, and platform development.</p>
+      </div>
+      <div class="offer-card">
+        <img src="/assets/globe.svg" alt="Network Access">
+        <h3>Network Access</h3>
+        <p>[PLACEHOLDER] Connect with the Open Data Policy Lab's global network of policymakers, technologists, and data practitioners.</p>
+      </div>
+    </div>
+  </nc-base-section>
 
-      <h3 class="margin-top:l">Inspirational Examples</h3>
-      <p>As this is an emerging area of practice, we understand that few organizations have developed data commons for AI. To help applicants think about how they may use data commons to support their work, we have assembled a list of instructive examples of data commons in action here.</p>
+  <!-- TODO(CCM-108): Replace with client copy — eligibility section -->
+  <nc-base-section color="faded">
+    <div class="eligibility-panel | switcher">
+      <div>
+        <h2>Who Should Apply</h2>
+      </div>
+      <div class="stack" style="--_stack-space: var(--space-2xs)">
+        <p>[PLACEHOLDER] We welcome applications from nonprofits, academic institutions,
+           startups, and development organisations working to build or strengthen
+           data commons for responsible AI.</p>
+        <h3 class="margin-top:s">Eligibility Criteria</h3>
+        <ul>
+          <li>[PLACEHOLDER] Must be affiliated with an established organisation capable of managing funds</li>
+          <li>[PLACEHOLDER] Project must focus on data commons that support responsible AI development</li>
+          <li>[PLACEHOLDER] Must demonstrate capacity to implement over 12 months</li>
+          <li>[PLACEHOLDER] Government entities may not apply as lead applicants</li>
+        </ul>
+      </div>
+    </div>
+  </nc-base-section>
 
-      <p>Please note that these data commons cover a range of topics beyond the areas of focus for this challenge.</p>
+  <nc-timeline :timeline="incubatorTimeline" title="Timeline" subtitle="Key dates for the 2026 Incubator:" />
+
+  <!-- TODO(CCM-108): Replace with client copy — application CTA -->
+  <nc-base-section>
+    <div class="cta-panel" style="border-radius: var(--border-radius-m);">
+      <div class="stack" style="text-align: center; max-width: 40rem; margin: 0 auto;">
+        <h2>Ready to Apply?</h2>
+        <p>[PLACEHOLDER] Submit your application by [DATE TBD]. Selected teams will be
+           notified by [DATE TBD] and the programme begins in [MONTH TBD] 2026.</p>
+        <nc-button href="#" color="primary" variant="primary">Apply Now</nc-button>
+      </div>
     </div>
   </nc-base-section>
 
@@ -115,7 +114,13 @@
 </template>
 
 <script setup>
-const { rulesUrl } = useSiteLinks()
+// TODO(CCM-108): Replace placeholder dates with confirmed dates
+const incubatorTimeline = [
+  { date: '2026-03-01T00:00:00-05:00', event: '[PLACEHOLDER] Applications open' },
+  { date: '2026-05-01T00:00:00-04:00', event: '[PLACEHOLDER] Applications close' },
+  { date: '2026-06-15T00:00:00-04:00', event: '[PLACEHOLDER] Cohort announced' },
+  { date: '2026-09-01T00:00:00-04:00', event: '[PLACEHOLDER] Programme begins' },
+]
 </script>
 
 <style scoped lang="scss">
@@ -134,29 +139,24 @@ const { rulesUrl } = useSiteLinks()
   }
 }
 
-.fancy-bg, .prize-cta { --overlap: 12rem; }
-
 .fancy-bg {
   background-image: url('/assets/bg-prize.png');
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
-  padding-bottom: calc(var(--overlap) + var(--space-2xl));
-}
-
-.prize-cta { margin-bottom: calc(var(--overlap) * -1); }
-
-.prize-cta > :first-child {
-  position: relative;
-  top: calc(var(--overlap) * -1);
-  z-index: 1;
 }
 
 .switcher {
   --_switcher-space: var(--space-s);
 }
 
-.prize-card {
+.offer-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--space-s);
+}
+
+.offer-card {
   background-color: var(--white-color);
   padding: 2.5rem;
   border-radius: var(--border-radius-m);
@@ -187,69 +187,21 @@ const { rulesUrl } = useSiteLinks()
   }
 }
 
+.eligibility-panel {
+  padding: var(--space-l-2xl);
+}
+
 .cta-panel {
   padding: var(--space-l-2xl);
   color: var(--white-color);
-
-  &:first-child {
-    background-color: var(--base-color);
-    border-radius: var(--border-radius-m) var(--border-radius-m) 0 0;
-  }
-
-  &:last-child {
-    border-radius: 0 0 var(--border-radius-m) var(--border-radius-m);
-    background: url('/assets/patterns/squares-left.svg') left bottom no-repeat, var(--secondary-color);
-  }
+  background-color: var(--base-color);
+  border-radius: var(--border-radius-m);
 
   :deep(svg path) {
     stroke: var(--white-color);
   }
 }
 
-.prize-list {
-  li {
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-    gap: var(--space-s);
-
-    p {
-      margin: 0;
-    }
-
-    img {
-      width: 2rem;
-      height: 2rem;
-      margin-left: -1.5rem;
-    }
-
-    span {
-      font-weight: 600;
-      font-size: 150%;
-      color: var(--primary-color);
-    }
-  }
-}
-
-.prize-tips {
-  color: var(--base-color);
-  h2 { grid-column: content-start / 5; }
-  .stack {
-    grid-column: 5 / content-end;
-    --_stack-space: var(--space-xs);
-  }
-
-  h3 {
-    font-size: var(--size-0);
-    font-weight: 600;
-    color: var(--primary-color);
-    text-transform: uppercase;
-  }
-
-  h4 {
-    font-size: var(--size-0);
-  }
-}
 .hero__announcement {
   text-align: left !important;
   padding: var(--space-m) var(--space-l);
@@ -277,9 +229,5 @@ const { rulesUrl } = useSiteLinks()
     color: var(--base-color);
     margin-block: var(--space-xs);
   }
-
-
-
 }
-
 </style>

--- a/pages/incubator/2026.vue
+++ b/pages/incubator/2026.vue
@@ -35,14 +35,11 @@
            takes a deeper, hands-on approach — working closely with selected teams to
            address technical, governance, and sustainability challenges.</p>
       </div>
-      <div>
-        <!-- Optional: image or illustration. Could reuse /assets/patterns/hero.jpg or a new asset -->
-      </div>
     </div>
   </nc-base-section>
 
   <!-- TODO(CCM-108): Replace with client copy — what we offer cards -->
-  <nc-base-section class="fancy-bg" color="primary">
+  <nc-base-section class="section-bg" color="primary">
     <h2 class="text-align:center padding-block:l white-color h2">What We Offer</h2>
     <div class="offer-cards">
       <div class="offer-card">
@@ -98,7 +95,7 @@
         <h2>Ready to Apply?</h2>
         <p>[PLACEHOLDER] Submit your application by [DATE TBD]. Selected teams will be
            notified by [DATE TBD] and the programme begins in [MONTH TBD] 2026.</p>
-        <nc-button href="#" color="primary" variant="primary">Apply Now</nc-button>
+        <nc-button disabled color="primary" variant="primary">Apply Now (Coming Soon)</nc-button>
       </div>
     </div>
   </nc-base-section>
@@ -139,7 +136,7 @@ const incubatorTimeline = [
   }
 }
 
-.fancy-bg {
+.section-bg {
   background-image: url('/assets/bg-prize.png');
   background-size: cover;
   background-position: center;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,40 +2,41 @@
   <nc-hero id="hero">
     <div class="hero__content">
       <div class="panel | stack">
-        <h1>New Commons Challenge</h1>
-        <p>The <b>Open Data Policy Lab</b> invites global changemakers to propose innovative data commons for generative
-          AI that serves the public interest. By enhancing data diversity, quality, and provenance, we can unlock AI’s
-          potential to innovate and solve complex challenges.</p>
-        <!--<nc-button el="a"
-          href="apply"
-          color="base"
-          variant="primary">Join the Challenge Today</nc-button>-->
+        <!-- TODO(CCM-108): Replace with client copy — hero headline and description -->
+        <h1>New Commons Incubator</h1>
+        <p>[PLACEHOLDER] The New Commons Incubator supports teams building data commons
+           for responsible AI. Through funding, mentorship, and technical resources, we help
+           turn promising ideas into sustainable shared data ecosystems.</p>
+        <nc-button el="a" to="/incubator/2026" color="base" variant="primary">Apply to the Incubator</nc-button>
       </div>
       <div class="hero__image-div">
-        
-        <img 
+
+        <img
           src="/assets/patterns/hero.jpg"
           alt="Hero Image" />
           <nc-minimal-logo />
       </div>
     </div>
     <nc-announcement color="primary" class="hero__announcement">
+      <!-- TODO(CCM-108): Replace with client copy — announcement bar -->
       <div class="switcher" style="">
         <div style="flex: 3;">
-          <h3>2025 New Commons Challenge</h3>
-            <h2>Meet the Awardees</h2>
-            <p>Explore the groundbreaking data commons recognized at the 2025 New Commons Showcase.</p>
+          <h3>Now Accepting Applications</h3>
+          <h2>2026 Incubator Cohort</h2>
+          <p>[PLACEHOLDER] Apply by [DATE TBD] to join the next cohort of teams building data commons for responsible AI.</p>
+          <NuxtLink to="/the-2025-challenge" style="font-size: var(--size-0); font-weight: 300; text-decoration: underline;">View the 2025 Challenge &rarr;</NuxtLink>
         </div>
-        <nc-button class="hero__announcement-button" to="/the-2025-challenge" color="primary" variant="primary" style="align-self: center;">View Awardees</nc-button>
+        <nc-button class="hero__announcement-button" to="/incubator/2026" color="primary" variant="primary" style="align-self: center;">Apply Now</nc-button>
       </div>
     </nc-announcement>
   </nc-hero>
 
   <nc-base-section id="video-section" width="narrow">
     <div class="panel" id="video">
-      <h2>The Challenge</h2>
-      <p>This video explains what the Challenge is and why data commons are key to developing responsible and effective
-        AI systems.</p>
+      <!-- TODO(CCM-108): Replace with client copy — video section heading and description -->
+      <h2>About the Incubator</h2>
+      <p>[PLACEHOLDER] Learn how the New Commons Incubator helps teams build sustainable data commons
+         for responsible AI development.</p>
     </div>
     <iframe class="video-frame" src="https://www.youtube.com/embed/gKqNJam8iEI?si=PGI4s_Zgns_JqSg8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
   </nc-base-section>
@@ -49,15 +50,18 @@
         <h2 class="padding-bottom:s">FAQs</h2>
         <div class="stack">
           <div>
-            <p>Have questions about the challenge?</p>
+            <!-- TODO(CCM-108): Replace with client copy — FAQ CTA text -->
+            <p>Have questions about the Incubator?</p>
             <p>Check out our FAQ page for all the answers you need to get started!</p>
           </div>
           <NuxtLink href="faq" class="button" color="white" variant="link">Read More <nc-arrow-link-up /></NuxtLink>
         </div>
       </div>
       <div class="panel-footer">
-        <h2>Watch the New Commons Challenge webinar</h2>
-        <p>Missed the live session? Catch up on our 5 May 2025 webinar to learn key details about the New Commons Challenge, including what we’re looking for and how to strengthen your concept note. We also answered live questions from prospective applicants.</p>
+        <!-- TODO(CCM-108): Replace with client copy — webinar section -->
+        <h2>Watch the Incubator Info Session</h2>
+        <p>[PLACEHOLDER] Missed the live session? Watch our webinar to learn about the 2026 Incubator,
+           including programme details, eligibility, and how to strengthen your application.</p>
         <nc-button href="#video" color="wt" variant="primary2">Watch now!</nc-button>
       </div>
     </div>
@@ -121,7 +125,7 @@ const { data: blogposts } = await useAsyncData('blogposts', () => queryCollectio
     color: var(--base-color);
     text-transform: uppercase;
   }
-  
+
   h2 {
     font-size: var(--size-2);
     font-weight: 300;
@@ -134,9 +138,9 @@ const { data: blogposts } = await useAsyncData('blogposts', () => queryCollectio
     color: var(--base-color);
     margin-block: var(--space-xs);
   }
-  
 
-  
+
+
 }
 
 
@@ -155,7 +159,7 @@ const { data: blogposts } = await useAsyncData('blogposts', () => queryCollectio
 
 #cta .cta-panel .panel-header {
   display: flex;
-  flex-direction: column;  
+  flex-direction: column;
   text-align: left;
   color: var(--white-color);
   background: url('/assets/patterns/squares.svg') left top no-repeat, #0E2F40;
@@ -191,15 +195,15 @@ const { data: blogposts } = await useAsyncData('blogposts', () => queryCollectio
   0% {
     translate: 0%;
   }
-  
+
   25%{
     translate: 2%;
   }
-  
+
   50%{
     translate: 0%;
   }
-  
+
   75%{
     translate: -2%;
   }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -7,7 +7,7 @@
         <p>[PLACEHOLDER] The New Commons Incubator supports teams building data commons
            for responsible AI. Through funding, mentorship, and technical resources, we help
            turn promising ideas into sustainable shared data ecosystems.</p>
-        <nc-button el="a" to="/incubator/2026" color="base" variant="primary">Apply to the Incubator</nc-button>
+        <nc-button to="/incubator/2026" color="base" variant="primary">Apply to the Incubator</nc-button>
       </div>
       <div class="hero__image-div">
 
@@ -41,7 +41,6 @@
     <iframe class="video-frame" src="https://www.youtube.com/embed/gKqNJam8iEI?si=PGI4s_Zgns_JqSg8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
   </nc-base-section>
 
-  <!--<nc-timeline id="timeline" />-->
 
   <nc-cta id="cta" :single-column="true">
     <div class="cta-panel"

--- a/todos/p1-ncbutton-el-a-with-to-broken-link.md
+++ b/todos/p1-ncbutton-el-a-with-to-broken-link.md
@@ -1,0 +1,25 @@
+# [P1] ncButton el="a" with to= attribute renders broken link
+
+## Finding
+
+In `index.vue` line 10, the hero CTA uses `<nc-button el="a" to="/incubator/2026">`. When `el="a"` is explicitly set, it overrides the auto-detection in `defaultEl` (which would choose `NuxtLink` for `to`). The result is a plain `<a>` element with a `to` attribute, which is not a valid HTML attribute for `<a>` tags. The link will not navigate anywhere.
+
+The fix is either:
+- Remove `el="a"` so auto-detection picks `NuxtLink` from the `to` attribute, OR
+- Change `to=` to `href=` to match the explicit `el="a"`
+
+## Location
+
+`pages/index.vue`, line 10:
+```html
+<nc-button el="a" to="/incubator/2026" color="base" variant="primary">Apply to the Incubator</nc-button>
+```
+
+## Suggested Fix
+
+```html
+<nc-button to="/incubator/2026" color="base" variant="primary">Apply to the Incubator</nc-button>
+```
+
+## Status
+- [ ] Pending

--- a/todos/p1-ncbutton-el-a-with-to-broken-link.md
+++ b/todos/p1-ncbutton-el-a-with-to-broken-link.md
@@ -22,4 +22,4 @@ The fix is either:
 ```
 
 ## Status
-- [ ] Pending
+- [x] Resolved

--- a/todos/p2-faq-html-comments-in-vhtml.md
+++ b/todos/p2-faq-html-comments-in-vhtml.md
@@ -1,0 +1,36 @@
+# [P2] FAQ TODO comments rendered in page source via v-html
+
+## Finding
+
+All FAQ `content` strings contain `<!-- TODO(CCM-108): ... -->` HTML comments. These are rendered into the DOM via `v-html` in `ncCollapse.vue`. While not a security risk (the content is developer-controlled, not user-supplied), these TODO comments will be visible in the page source to anyone who inspects the HTML, which looks unprofessional in production.
+
+This affects all 15 FAQ entries in `pages/faq.vue`.
+
+## Location
+
+`pages/faq.vue`, lines 38, 47, 60, 69, 80, 88, 97, 108, 117, 125, 136, 145, 156, 169, 180, 189 (every `content` field).
+
+Example (line 38):
+```js
+content: `
+  <!-- TODO(CCM-108): Replace with client copy — program description -->
+  <p>[PLACEHOLDER] The New Commons Incubator is a 12-month programme...</p>
+`
+```
+
+## Suggested Fix
+
+Move the TODO comments outside the `content` strings, as JS comments above each object:
+
+```js
+// TODO(CCM-108): Replace with client copy — program description
+{
+  summary: 'What is the New Commons Incubator?',
+  content: `<p>[PLACEHOLDER] The New Commons Incubator is a 12-month programme...</p>`
+},
+```
+
+This keeps the TODO markers grep-able but keeps them out of the rendered HTML.
+
+## Status
+- [ ] Pending

--- a/todos/p2-faq-html-comments-in-vhtml.md
+++ b/todos/p2-faq-html-comments-in-vhtml.md
@@ -33,4 +33,4 @@ Move the TODO comments outside the `content` strings, as JS comments above each 
 This keeps the TODO markers grep-able but keeps them out of the rendered HTML.
 
 ## Status
-- [ ] Pending
+- [x] Resolved

--- a/todos/p2-incubator-apply-now-href-hash.md
+++ b/todos/p2-incubator-apply-now-href-hash.md
@@ -19,4 +19,4 @@ Either:
 3. If this is expected to be replaced before production, add a visible "(Coming Soon)" label
 
 ## Status
-- [ ] Pending
+- [x] Resolved

--- a/todos/p2-incubator-apply-now-href-hash.md
+++ b/todos/p2-incubator-apply-now-href-hash.md
@@ -1,0 +1,22 @@
+# [P2] "Apply Now" button uses href="#" placeholder
+
+## Finding
+
+In the incubator/2026.vue application CTA section (line 101), the "Apply Now" button uses `href="#"` as a placeholder. This is a clickable button that scrolls to the top of the page and adds `#` to the URL, which is confusing for users and bad for accessibility (screen readers announce it as a link).
+
+## Location
+
+`pages/incubator/2026.vue`, line 101:
+```html
+<nc-button href="#" color="primary" variant="primary">Apply Now</nc-button>
+```
+
+## Suggested Fix
+
+Either:
+1. Disable the button until a real URL is available: `<nc-button disabled color="primary" variant="primary">Apply Now (Coming Soon)</nc-button>`
+2. Use a more explicit placeholder: `href="/incubator/2026#apply"` with an anchor, or link to a "coming soon" page
+3. If this is expected to be replaced before production, add a visible "(Coming Soon)" label
+
+## Status
+- [ ] Pending

--- a/todos/p2-nctimeline-backward-compat-broken.md
+++ b/todos/p2-nctimeline-backward-compat-broken.md
@@ -1,0 +1,35 @@
+# [P2] ncTimeline refactor breaks backward compatibility
+
+## Finding
+
+The `ncTimeline` component was refactored from a self-contained component with hardcoded data to a prop-driven component where `timeline` is `required: true`. The old usage pattern `<nc-timeline id="timeline" />` (still present commented-out on `index.vue` line 44) would now fail with a Vue warning if uncommented, since no `timeline` prop is passed.
+
+While the commented-out usage is not actively broken, any other consumer of this component (or someone uncommenting the line) would get a runtime error. The component API changed without a default fallback.
+
+## Location
+
+`components/ncTimeline.vue`, lines 21-25:
+```js
+const props = defineProps({
+  timeline: {
+    type: Array,
+    required: true,
+    ...
+```
+
+`pages/index.vue`, line 44 (unchanged, but now incompatible):
+```html
+<!--<nc-timeline id="timeline" />-->
+```
+
+## Suggested Fix
+
+Either:
+1. Add a `default: () => []` to the timeline prop and handle empty state gracefully, OR
+2. Update the commented-out usage in `index.vue` to pass the required prop, OR
+3. Remove the commented-out line entirely since the old Challenge timeline is no longer relevant
+
+Option 3 is recommended since the old data is gone anyway.
+
+## Status
+- [ ] Pending

--- a/todos/p2-nctimeline-backward-compat-broken.md
+++ b/todos/p2-nctimeline-backward-compat-broken.md
@@ -32,4 +32,4 @@ Either:
 Option 3 is recommended since the old data is gone anyway.
 
 ## Status
-- [ ] Pending
+- [x] Resolved

--- a/todos/p2-nctimeline-ssr-hydration-mismatch.md
+++ b/todos/p2-nctimeline-ssr-hydration-mismatch.md
@@ -31,4 +31,4 @@ const now = useState('timeline-now', () => new Date())
 ```
 
 ## Status
-- [ ] Pending
+- [x] Resolved

--- a/todos/p2-nctimeline-ssr-hydration-mismatch.md
+++ b/todos/p2-nctimeline-ssr-hydration-mismatch.md
@@ -1,0 +1,34 @@
+# [P2] ncTimeline SSR hydration mismatch from new Date()
+
+## Finding
+
+In the refactored `ncTimeline.vue`, `const now = new Date()` is evaluated at the module scope during both SSR and client hydration. The server renders at one timestamp; the client hydrates at a different timestamp seconds later. If a timeline date falls between these two instants, the `isActive()` and `isFull()` functions produce different class bindings on server vs client, causing a Vue hydration mismatch warning and potential visual flicker.
+
+This is a new issue introduced by this PR. The old code used static class bindings (`i <= 4`, `i <= 3`) that did not depend on the current time.
+
+## Location
+
+`components/ncTimeline.vue`, line 31:
+```js
+const now = new Date()
+```
+
+## Suggested Fix
+
+Use a client-only reactive date, or wrap the date in `onMounted` / `useState` to ensure consistent SSR/client values:
+
+```js
+const now = ref(new Date())
+onMounted(() => {
+  now.value = new Date()
+})
+```
+
+Or use Nuxt's `useState` to share the value between SSR and client:
+
+```js
+const now = useState('timeline-now', () => new Date())
+```
+
+## Status
+- [ ] Pending

--- a/todos/p3-incubator-empty-div-program-overview.md
+++ b/todos/p3-incubator-empty-div-program-overview.md
@@ -21,4 +21,4 @@ Either:
 3. At minimum, hide the empty div with `v-if="false"` or remove it
 
 ## Status
-- [ ] Pending
+- [x] Resolved

--- a/todos/p3-incubator-empty-div-program-overview.md
+++ b/todos/p3-incubator-empty-div-program-overview.md
@@ -1,0 +1,24 @@
+# [P3] Empty div in program overview section
+
+## Finding
+
+The program overview section on `incubator/2026.vue` has a `.switcher` layout with two children: a `.stack` div with text content, and an empty `<div>` with only an HTML comment about an optional image. This empty div takes up space in the switcher layout, creating an awkward gap on desktop.
+
+## Location
+
+`pages/incubator/2026.vue`, lines 38-40:
+```html
+<div>
+  <!-- Optional: image or illustration. Could reuse /assets/patterns/hero.jpg or a new asset -->
+</div>
+```
+
+## Suggested Fix
+
+Either:
+1. Remove the empty div and the `.switcher` wrapper, using a single-column layout until an image is available
+2. Add a placeholder image
+3. At minimum, hide the empty div with `v-if="false"` or remove it
+
+## Status
+- [ ] Pending

--- a/todos/p3-incubator-fancy-bg-misleading-name.md
+++ b/todos/p3-incubator-fancy-bg-misleading-name.md
@@ -1,0 +1,22 @@
+# [P3] .fancy-bg class name and bg-prize.png asset reference are misleading
+
+## Finding
+
+The "What We Offer" section in `incubator/2026.vue` reuses the `.fancy-bg` CSS class which references `bg-prize.png` as its background image. The class name and asset name both reference the old "prize" concept which no longer applies to the Incubator page.
+
+## Location
+
+`pages/incubator/2026.vue`, lines 142-147:
+```css
+.fancy-bg {
+  background-image: url('/assets/bg-prize.png');
+  ...
+}
+```
+
+## Suggested Fix
+
+Rename the class to `.offer-bg` or `.section-bg` and consider renaming or replacing the background image asset if it carries prize-specific branding.
+
+## Status
+- [ ] Pending

--- a/todos/p3-incubator-fancy-bg-misleading-name.md
+++ b/todos/p3-incubator-fancy-bg-misleading-name.md
@@ -19,4 +19,4 @@ The "What We Offer" section in `incubator/2026.vue` reuses the `.fancy-bg` CSS c
 Rename the class to `.offer-bg` or `.section-bg` and consider renaming or replacing the background image asset if it carries prize-specific branding.
 
 ## Status
-- [ ] Pending
+- [x] Resolved

--- a/todos/p3-nctimeline-empty-css-rule.md
+++ b/todos/p3-nctimeline-empty-css-rule.md
@@ -1,0 +1,20 @@
+# [P3] Empty CSS rule block in ncTimeline
+
+## Finding
+
+There is an empty `.timeline {}` rule block at line 70-71 of `ncTimeline.vue`. This is dead code left over from the refactor.
+
+## Location
+
+`components/ncTimeline.vue`, lines 70-71:
+```css
+.timeline {
+}
+```
+
+## Suggested Fix
+
+Remove the empty rule block.
+
+## Status
+- [ ] Pending

--- a/todos/p3-nctimeline-empty-css-rule.md
+++ b/todos/p3-nctimeline-empty-css-rule.md
@@ -17,4 +17,4 @@ There is an empty `.timeline {}` rule block at line 70-71 of `ncTimeline.vue`. T
 Remove the empty rule block.
 
 ## Status
-- [ ] Pending
+- [x] Resolved

--- a/todos/p3-nctimeline-index-key.md
+++ b/todos/p3-nctimeline-index-key.md
@@ -18,4 +18,4 @@ The `v-for` loop in `ncTimeline.vue` uses `:key="i"` (the array index). If the t
 ```
 
 ## Status
-- [ ] Pending
+- [x] Resolved

--- a/todos/p3-nctimeline-index-key.md
+++ b/todos/p3-nctimeline-index-key.md
@@ -1,0 +1,21 @@
+# [P3] ncTimeline uses array index as v-for key
+
+## Finding
+
+The `v-for` loop in `ncTimeline.vue` uses `:key="i"` (the array index). If the timeline array is ever reordered or items inserted, Vue cannot efficiently reconcile the DOM. Using a unique property like the date string would be more robust.
+
+## Location
+
+`components/ncTimeline.vue`, line 7:
+```html
+<div class="card" ... v-for="(item, i) in timeline" :key="i">
+```
+
+## Suggested Fix
+
+```html
+<div class="card" ... v-for="(item, i) in timeline" :key="item.date">
+```
+
+## Status
+- [ ] Pending


### PR DESCRIPTION
## Summary

- **FAQ page**: Replaced all 8 Challenge FAQ categories (40+ Q&As) with 6 Incubator-focused categories (18 Q&As) — program, eligibility, application, support, timeline, governance
- **Homepage**: Updated hero, announcement bar, video section, and CTA panels from Challenge to Incubator messaging; added "Apply to the Incubator" CTA and secondary "View the 2025 Challenge" archive link
- **Incubator page** (`/incubator/2026`): Removed placeholder banner, old prize/tips sections; added Program Overview, What We Offer (4 cards), Who Should Apply, Timeline, and Application CTA sections; kept Judges & Observers grids
- **ncTimeline component**: Refactored from hardcoded 4-item array to prop-driven (`timeline`, `title`, `subtitle`) with dynamic active/full state based on current date; simplified progress bar CSS to solid colour for any item count

All placeholder text is prefixed with `[PLACEHOLDER]` and marked with `<!-- TODO(CCM-108) -->` comments for easy audit and client copy replacement.

## Test plan

- [ ] All three pages render without errors (`/`, `/faq`, `/incubator/2026`)
- [ ] FAQ accordions open/close correctly with new content
- [ ] No unintended "Challenge" references remain in Incubator-era content
- [ ] YouTube embed still plays on homepage
- [ ] Judges and Observers grids render on incubator page
- [ ] `grep -r "TODO(CCM-108)"` returns all placeholder locations
- [ ] Page looks reasonable on mobile (no layout regressions)
- [ ] "View the 2025 Challenge" link navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)