### PR TITLE
content: apply Hannah's review + drop resources category taxonomy

### DIFF
--- a/components/ncCallForProposals.vue
+++ b/components/ncCallForProposals.vue
@@ -3,7 +3,7 @@
     <div class="stack">
       <p class="brow">Call for Proposals</p>
       <h2 class="cfp-heading">Data Commons for Indigenous Languages and Cultures</h2>
-      <p class="cfp-tagline">{{ tagline }}</p>
+      <p class="cfp-tagline" v-html="tagline"></p>
       <nc-button to="/incubator/2026/application" color="primary" variant="primary">Apply Now</nc-button>
     </div>
     <template v-if="hasSecondary" #right>
@@ -43,6 +43,17 @@ const hasSecondary = computed(() => !!slots.secondary)
 
 .cfp-tagline {
   max-width: 50ch;
+}
+
+.cfp-tagline :deep(a) {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+  font-weight: 600;
+}
+
+.cfp-tagline :deep(a:hover) {
+  text-decoration-thickness: 2px;
 }
 
 @media (max-width: 920px) {

--- a/components/ncResourceCard.vue
+++ b/components/ncResourceCard.vue
@@ -12,7 +12,6 @@
       :alt="content.title || 'Resource image'"
       class="resource-card__image"
     >
-    <span class="resource-card__category">{{ content.category }}</span>
     <h3 class="resource-card__title">{{ content.title }}</h3>
     <p class="resource-card__description">{{ content.description }}</p>
     <ncButton v-if="hasLink" el="span" label="View resource" class="resource-card__cta | margin-top:s" />
@@ -53,15 +52,6 @@ const hasLink = computed(() => props.content && getResourceLink(props.content) !
   width: 100%;
   aspect-ratio: 16 / 9;
   object-fit: cover;
-}
-
-.resource-card__category {
-  display: inline-block;
-  font-size: var(--size--1);
-  font-weight: 600;
-  text-transform: uppercase;
-  color: var(--primary-color);
-  letter-spacing: 0.05em;
 }
 
 .resource-card__title { line-height: 1.35; }

--- a/composables/useResources.js
+++ b/composables/useResources.js
@@ -12,16 +12,9 @@ export default function useResources() {
     return link.startsWith('http') || link.startsWith('//')
   }
 
-  const categories = (resources) => {
-    if (!resources?.length) return []
-    const cats = [...new Set(resources.map(r => r.category).filter(Boolean))]
-    return cats.sort()
-  }
-
   return {
     getImage,
     getResourceLink,
     isExternalLink,
-    categories,
   }
 }

--- a/content.config.ts
+++ b/content.config.ts
@@ -67,8 +67,8 @@ export default defineContentConfig({
       schema: z.object({
         title: z.string(),
         slug: z.string(),
+        sort: z.number().nullable().optional(),
         description: z.string(),
-        category: z.string().optional(),
         // At least one of url or file should be provided; ncResourceCard
         // renders a non-linked fallback card when neither is set.
         url: z.string().optional(),

--- a/directus/resources.js
+++ b/directus/resources.js
@@ -18,8 +18,8 @@ const objectContructor = async (dir, fs) => {
     let i = {};
     i.title = item.title;
     i.slug = common.slugify(item.title);
+    i.sort = item.sort ?? null;
     i.description = item.description || '';
-    i.category = item.category || '';
     i.url = item.url || '';
     i.file = item.file ? common.getImage(item.file.id) : '';
     i.cover_image = item.cover_image ? common.getImage(item.cover_image.id) : '';

--- a/pages/faq.vue
+++ b/pages/faq.vue
@@ -43,7 +43,7 @@ const faq = {
       content: `
         <p>The Incubator will follow the schedule outlined below:</p>
         <ul>
-          <li><strong>Applications Open:</strong> May (TBC)</li>
+          <li><strong>Applications Open:</strong> May</li>
           <li><strong>Informational Webinars:</strong> w/o 25 May 2026 and 1 June 2026</li>
           <li><strong>Applications Close:</strong> 10 July 2026</li>
           <li><strong>Cohort Selection:</strong> Late August</li>

--- a/pages/incubator/2026.vue
+++ b/pages/incubator/2026.vue
@@ -4,7 +4,7 @@
       <div class="panel | stack">
         <p class="hero__brow">BUILDING A SHARED DIGITAL FUTURE</p>
         <h1>The New Commons Incubator</h1>
-        <p>The Incubator is a global effort led by the Open Data Policy Lab that aims to unlock data commons for public-interest AI.</p>
+        <p>The Incubator is a global effort led by the <a href="https://opendatapolicylab.org" target="_blank" rel="noopener">Open Data Policy Lab</a> that aims to unlock data commons for public-interest AI.</p>
         <p>The Incubator addresses a critical issue: the limited access to diverse and high-quality datasets, which is essential for AI to reach its full potential. By creating and improving data commons, which are collaboratively governed data ecosystems that pool and provide responsible access to diverse, high-quality datasets, the gap in AI development can be filled.</p>
         <p>Through structured programming, the Incubator will develop a pipeline of trusted, community-governed data commons that enable responsible AI development while safeguarding data rights, context, and community agency.</p>
       </div>
@@ -41,7 +41,7 @@
     <div class="programmatic-offerings">
       <div class="programmatic-offerings__text | stack">
         <h2>Programmatic Offerings</h2>
-        <p>The Incubator is a structured program designed to support data leaders in setting up a data commons. It will include an in-person kickoff event to set stage, virtual programming and mentorship, and a final showcase.</p>
+        <p>The Incubator is a structured program designed to support data leaders in setting up a data commons. It will include an in-person kickoff event to set the stage as well as virtual programming and mentorship, and a final showcase.</p>
       </div>
       <div class="programmatic-offerings__list | stack">
         <h3>Throughout the programming, participants will:</h3>

--- a/pages/incubator/indigenous-languages.vue
+++ b/pages/incubator/indigenous-languages.vue
@@ -73,22 +73,13 @@
     </div>
   </nc-base-section>
 
-  <nc-base-section size="l">
+  <nc-base-section id="steering-committee" size="l">
     <div class="stack steering-committee">
       <h2 class="text-align:center">Steering Committee</h2>
       <p class="text-align:center">This initiative is supported by a Steering Committee of Indigenous experts and representatives to ensure this work is productive and complementary to existing Indigenous-led efforts. The Steering Committee offers input on all major decisions and the partner organizations aim to ensure their guidance is reflected in all activities.</p>
       <nc-people-grid :collection="steeringCommittee" base-path="/incubator/indigenous-languages" image-base-path="" />
     </div>
   </nc-base-section>
-
-  <nc-cta single-column>
-    <div class="stack how-to-apply">
-      <p class="brow">How to Apply</p>
-      <h2 class="how-to-apply__heading">Submit your concept note</h2>
-      <p class="how-to-apply__tagline">Interested applicants need to submit a 2-page concept note using our application form by <strong>10 July 2026</strong>.</p>
-      <nc-button to="/incubator/2026/application" color="primary" variant="primary">Apply Now</nc-button>
-    </div>
-  </nc-cta>
 
   <nc-timeline
     :timeline="timelineData"
@@ -174,32 +165,6 @@ const timelineData = [
 .steering-committee :deep(.grid) {
   max-width: 48rem;
   margin-inline: auto;
-}
-
-.how-to-apply {
-  .brow {
-    text-transform: uppercase;
-    color: rgba(255, 255, 255, 0.8);
-    font-weight: 800;
-    font-size: var(--size-0);
-    letter-spacing: 0.05em;
-  }
-
-  &__heading {
-    margin-top: 0;
-    font-size: var(--size-3);
-    color: var(--white-color);
-  }
-
-  &__tagline {
-    max-width: 50ch;
-  }
-
-  @media (max-width: 920px) {
-    &__tagline {
-      max-width: 100%;
-    }
-  }
 }
 
 .programmatic-offerings {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -17,7 +17,7 @@
 
   <nc-call-for-proposals
     id="call-for-proposals"
-    tagline="The Open Data Policy Lab invites changemakers around the world to join us and our steering committee of Indigenous data experts in developing data commons for Indigenous languages and cultures."
+    tagline='The Open Data Policy Lab invites changemakers around the world to join us and <a href="/incubator/indigenous-languages#steering-committee">our steering committee of Indigenous data experts</a> in developing data commons for Indigenous languages and cultures.'
   >
     <template #secondary>
       <h3>Join Our Informational Webinars</h3>
@@ -80,7 +80,7 @@ const { data: blogposts } = await useAsyncData('blogposts', () =>
 )
 
 const { data: resources } = await useAsyncData('homepage-resources', () =>
-  queryCollection('resources').limit(3).all()
+  queryCollection('resources').order('sort', 'ASC').limit(3).all()
 )
 </script>
 
@@ -119,13 +119,15 @@ const { data: resources } = await useAsyncData('homepage-resources', () =>
   grid-template-columns: minmax(200px, 1fr) 2fr;
   gap: var(--space-xl);
   align-items: start;
-  border-top: 1px solid var(--base-color-10-tint);
-  border-bottom: 1px solid var(--base-color-10-tint);
-  padding-block: var(--space-xl);
+  background-color: var(--base-color-05-tint);
+  border: 1px solid var(--base-color-10-tint);
+  border-radius: var(--border-radius-l);
+  padding: var(--space-xl);
 
   @media (max-width: 768px) {
     grid-template-columns: 1fr;
     gap: var(--space-m);
+    padding: var(--space-l);
   }
 }
 

--- a/pages/resources/index.vue
+++ b/pages/resources/index.vue
@@ -6,32 +6,14 @@
   </nc-base-section>
 
   <nc-base-section>
-    <!-- Category filter buttons -->
-    <div class="resource-filters | cluster">
-      <button
-        class="filter-pill"
-        :class="{ 'filter-pill--active': !activeCategory }"
-        @click="activeCategory = null"
-      >All</button>
-      <button
-        v-for="cat in categoryList"
-        :key="cat"
-        class="filter-pill"
-        :class="{ 'filter-pill--active': activeCategory === cat }"
-        @click="activeCategory = cat"
-      >{{ cat }}</button>
-    </div>
-  </nc-base-section>
-
-  <nc-base-section>
     <div class="grid resource-grid">
       <nc-resource-card
-        v-for="resource in filteredResources"
+        v-for="resource in resources"
         :key="resource.slug"
         :content="resource"
       />
     </div>
-    <p v-if="!filteredResources?.length" class="text-align:center">
+    <p v-if="!resources?.length" class="text-align:center">
       No resources found.
     </p>
   </nc-base-section>
@@ -46,19 +28,8 @@ useSeoMeta({
 })
 
 const { data: resources } = await useAsyncData('resources', () =>
-  queryCollection('resources').all()
+  queryCollection('resources').order('sort', 'ASC').all()
 )
-
-const { categories } = useResources()
-
-const activeCategory = ref(null)
-
-const categoryList = computed(() => categories(resources.value))
-
-const filteredResources = computed(() => {
-  if (!activeCategory.value) return resources.value ?? []
-  return (resources.value ?? []).filter(r => r.category === activeCategory.value)
-})
 </script>
 
 <style scoped>
@@ -84,27 +55,5 @@ const filteredResources = computed(() => {
   font-size: var(--size-1);
   color: var(--base-color-70-tint);
   font-weight: 300;
-}
-
-.filter-pill {
-  border: 1px solid var(--base-color-10-tint);
-  background: white;
-  padding: var(--space-3xs) var(--space-s);
-  border-radius: 999px;
-  font-size: var(--size--1);
-  font-weight: 500;
-  cursor: pointer;
-  transition: background 150ms ease, color 150ms ease;
-  text-transform: capitalize;
-}
-
-.filter-pill--active {
-  background: var(--primary-color);
-  color: white;
-  border-color: var(--primary-color);
-}
-
-.filter-pill:hover:not(.filter-pill--active) {
-  background: var(--base-color-07-tint);
 }
 </style>


### PR DESCRIPTION
## Summary

Applies Hannah Chafetz's feedback on the dev site ([doc](https://docs.google.com/document/d/1tKsMwYsGqjXKkQ7c_v6Yjb0ELdRcT83nn25XxT39izg/edit)) and refactors the Resources taxonomy per her "these are all resources" comment. Status annotations for each item are tracked in our [CCM working copy](https://docs.google.com/document/d/1o4xdYE-Ouu8T829erMxY6H7V_JSICXiv2ok4gE8iMBI/edit).

### Quick wins (copy + small UI)

- **Incubator (/incubator/2026):** fix "set the stage" typo; hyperlink "Open Data Policy Lab" → opendatapolicylab.org
- **FAQ:** remove "(TBC)" from "Applications Open: May"
- **Home:** wrap New Commons definition in a bordered box
- **Home:** hyperlink _"our steering committee of Indigenous data experts"_ → `/incubator/indigenous-languages#steering-committee`. `ncCallForProposals` now renders `tagline` via `v-html` so links can be embedded.
- **Indigenous Languages:** add `#steering-committee` anchor; remove the redundant "How to Apply" CTA (primary Call for Proposals above it is retained)
- **Resource cards:** drop the blue Toolkit/Blueprint category label

### Resources restructure

Hannah: _"Can remove the light blue text at the top 'Toolkit' / 'Blueprint' since these are all resources."_ Taken to its logical conclusion — category distinctions aren't meaningful, so the filter UI goes too.

- Drop `category` field from **Directus collection**, content importer, Nuxt Content schema, and `useResources` helper
- Remove filter pill UI from `/resources`
- Wire Directus `sort` through importer + schema + queries so the existing drag-drop in `/admin/content/new_commons_resources` drives site order (home top 3 + `/resources` full list)

### Directus admin changes (applied in parallel, production CMS)

- Renamed resource ID 2: _"Appendix A: Data Commons Canvas"_ → **"Data Commons Worksheets"** + new description
- Renamed resource ID 3: _"Appendix B: Example Data Commons"_ → **"Taxonomy of Use Cases"** + new description
- Uploaded cover images: first page of Appendix A PDF (Worksheets); cropped Miro topic map (Taxonomy)
- Deleted the now-unused `category` field from the collection schema

### Out of scope for this PR

Larger tasks from Hannah's doc still pending: site-wide visual direction, top-panel visuals on Incubator/ILC, UNESCO logo swap (awaiting asset), steering-committee headshots/bios, timeline relocation on ILC, visual distinction between generic Incubator and ILC. Also deferred: the "odd spacing" item (needs clarification on which section).

## Test plan

- [x] `/` — New Commons definition appears in a bordered box
- [ ] `/` — Call for Proposals tagline has underlined link on "our steering committee of Indigenous data experts"; link scrolls to steering committee on ILC page
- [x] `/` — Resources section shows Blueprint, Data Commons Worksheets, Taxonomy of Use Cases (home top 3 driven by Directus `sort`)
- [x] `/incubator/2026` — first paragraph has "Open Data Policy Lab" as a link; programmatic offerings paragraph reads "…set the stage as well as virtual programming and mentorship…"
- [ ] `/incubator/indigenous-languages` — no second "How to Apply" CTA between Steering Committee and Timeline; Steering Committee section has anchor id
- [ ] `/faq` — "Applications Open: May" (no "(TBC)")
- [x] `/resources` — no filter pills; 6 cards in Directus `sort` order; no category labels on any card
- [x] In Directus: drag rows in `new_commons_resources` to a new order → after rebuild, site order reflects change

🤖 Generated with [Claude Code](https://claude.com/claude-code)