### PR TITLE
Resolve Apr 17 feedback contradictions: Programmatic Offerings copy + redundant CTA

### DIFF
--- a/_process/sitemap.yml
+++ b/_process/sitemap.yml
@@ -75,7 +75,7 @@
 
 ## section: programmatic-offerings
   title: Programmatic Offerings
-  tagline: The Incubator is a X-week structured program designed to support data leaders in setting up a data commons. It will include an in-person kickoff event to set stage, virtual programming and mentorship, and a final showcase.
+  tagline: The Incubator is a structured program designed to support data leaders in setting up a data commons. It will include an in-person kickoff event to set the stage as well as virtual programming and mentorship, and a final showcase.
   items:
     - Design and implement accountable and context-specific data governance frameworks
     - Build AI-ready datasets grounded in community consent and social license

--- a/_process/sitemap/2-incubator.md
+++ b/_process/sitemap/2-incubator.md
@@ -44,7 +44,7 @@ body: |
 ## programmatic-offerings
 
 title: Programmatic Offerings
-tagline: The Incubator is a X-week structured program designed to support data leaders in setting up a data commons. It will include an in-person kickoff event to set stage, virtual programming and mentorship, and a final showcase.
+tagline: The Incubator is a structured program designed to support data leaders in setting up a data commons. It will include an in-person kickoff event to set the stage as well as virtual programming and mentorship, and a final showcase.
 items:
 
 - Design and implement accountable and context-specific data governance frameworks

--- a/pages/incubator/2026.vue
+++ b/pages/incubator/2026.vue
@@ -41,7 +41,7 @@
     <div class="programmatic-offerings">
       <div class="programmatic-offerings__text | stack">
         <h2>Programmatic Offerings</h2>
-        <p>The Incubator is a structured program designed to support data leaders in setting up a data commons. It will include an in-person kickoff event to set stage, virtual programming and mentorship, and a final showcase.</p>
+        <p>The Incubator is a structured program designed to support data leaders in setting up a data commons. It will include an in-person kickoff event to set the stage as well as virtual programming and mentorship, and a final showcase.</p>
       </div>
       <div class="programmatic-offerings__list | stack">
         <h3>Throughout the programming, participants will:</h3>

--- a/pages/incubator/indigenous-languages.vue
+++ b/pages/incubator/indigenous-languages.vue
@@ -81,15 +81,6 @@
     </div>
   </nc-base-section>
 
-  <nc-cta single-column>
-    <div class="stack how-to-apply">
-      <p class="brow">How to Apply</p>
-      <h2 class="how-to-apply__heading">Submit your concept note</h2>
-      <p class="how-to-apply__tagline">Interested applicants need to submit a 2-page concept note using our application form by <strong>10 July 2026</strong>.</p>
-      <nc-button to="/incubator/2026/application" color="primary" variant="primary">Apply Now</nc-button>
-    </div>
-  </nc-cta>
-
   <nc-timeline
     :timeline="timelineData"
     title="Timeline"
@@ -174,32 +165,6 @@ const timelineData = [
 .steering-committee :deep(.grid) {
   max-width: 48rem;
   margin-inline: auto;
-}
-
-.how-to-apply {
-  .brow {
-    text-transform: uppercase;
-    color: rgba(255, 255, 255, 0.8);
-    font-weight: 800;
-    font-size: var(--size-0);
-    letter-spacing: 0.05em;
-  }
-
-  &__heading {
-    margin-top: 0;
-    font-size: var(--size-3);
-    color: var(--white-color);
-  }
-
-  &__tagline {
-    max-width: 50ch;
-  }
-
-  @media (max-width: 920px) {
-    &__tagline {
-      max-width: 100%;
-    }
-  }
 }
 
 .programmatic-offerings {


### PR DESCRIPTION
## Summary

Applies three of Hannah's Apr 17 feedback items that contradicted the Mar 30 content brief. Per discussion, the Apr 17 feedback is treated as the new source of truth for these items.

- **Incubator page — Programmatic Offerings copy:** Hannah flagged the existing sentence as a "typo." It was not a typo but a rewrite — applied anyway. New tagline: *"The Incubator is a structured program designed to support data leaders in setting up a data commons. It will include an in-person kickoff event to set the stage as well as virtual programming and mentorship, and a final showcase."*
- **Indigenous Languages page — duplicate "How to Apply":** The Mar 30 brief asked for both a top Call for Proposals and a bottom "How to Apply" CTA. Hannah's Apr 17 feedback called the second one redundant. Removed the bottom `<nc-cta>` block; the top `<nc-call-for-proposals>` already carries Apply Now.
- **Orphan CSS + sitemap drift:** Stripped the now-unused `.how-to-apply` SCSS in `indigenous-languages.vue`. Synced `_process/sitemap.yml` and `_process/sitemap/2-incubator.md` taglines to match the new page copy.

## Not in this PR

- **Resources naming** (Hannah's 5th contradiction — "Data Commons Canvas" vs "Data Commons Worksheets"; "Example Data Commons" vs "Taxonomy of Use Cases"): Directus already holds the latest titles (id=2 "Data Commons Worksheets", id=3 "Taxonomy of Use Cases", both published). No CMS edit needed — the stale dev deploy just needs a rebuild.
- **Other contradictions (Homepage CFP banner placement, Timeline ordering):** Deferred — those require a design decision from Hannah, not a copy edit.

## Test plan

- [ ] `/incubator/2026` renders the new Programmatic Offerings tagline.
- [ ] `/incubator/indigenous-languages` no longer shows the bottom "How to Apply" / "Submit your concept note" CTA panel (timeline follows directly after Steering Committee).
- [ ] No visual regression on the Indigenous Languages page (the `.how-to-apply` SCSS was only referenced by the removed block).
- [ ] After next Directus-driven rebuild, `/resources` lists "Data Commons Worksheets" and "Taxonomy of Use Cases" (not "Appendix A/B").

🤖 Generated with [Claude Code](https://claude.com/claude-code)