### PR TITLE
content(ilc): tighten programmatic-offerings spacing + move quote to Why

### DIFF
--- a/pages/incubator/2026.vue
+++ b/pages/incubator/2026.vue
@@ -143,6 +143,8 @@ useSeoMeta({
   }
 
   &__list {
+    --_stack-space: var(--space-s);
+
     ul {
       list-style: none;
       padding: 0;

--- a/pages/incubator/indigenous-languages.vue
+++ b/pages/incubator/indigenous-languages.vue
@@ -30,6 +30,9 @@
           <li>When included, data is often extracted without consent or benefit.</li>
           <li>And even well-intentioned efforts frequently strip away the cultural context that gives these languages meaning.</li>
         </ul>
+        <blockquote class="our-approach__quote">
+          <p>This represents both a technical and governance breakdown. What's needed is a <strong>new institutional approach</strong>.</p>
+        </blockquote>
       </div>
       <div class="why-section__image">
         <img
@@ -43,9 +46,6 @@
   <nc-base-section size="l">
     <div class="our-approach | stack">
       <h2>Our Approach</h2>
-      <blockquote class="our-approach__quote">
-        <p>This represents both a technical and governance breakdown. What's needed is a <strong>new institutional approach</strong>.</p>
-      </blockquote>
       <p class="our-approach__body">The <strong><em>New Commons Incubator for Indigenous Languages and Cultures</em></strong> advances a <a href="https://incubator.opendatapolicylab.org/files/data-commons-for-ai-blueprint.pdf" target="_blank" rel="noopener noreferrer">data commons model</a> that enables responsible access to high-quality data while ensuring any access and use remains aligned with Indigenous values and expectations. It shifts the framework from extraction by outside parties to <strong>collective stewardship led by Indigenous communities themselves</strong>, ensuring that data is governed, shared, and used on community-defined terms.</p>
     </div>
   </nc-base-section>
@@ -272,6 +272,8 @@ const timelineData = [
   }
 
   &__list {
+    --_stack-space: var(--space-s);
+
     ul {
       list-style: none;
       padding: 0;


### PR DESCRIPTION
## Summary

Two small edits from the 2026-04-21 call with Hannah Chafetz.

- **Programmatic Offerings spacing** — `.programmatic-offerings__list` now sets `--_stack-space: var(--space-s)` so the h3 title sits closer to its bullets and matches the text column's rhythm. Applied on both `/incubator/2026` and `/incubator/indigenous-languages`.
- **Quote reordered on indigenous-languages** — the "technical and governance breakdown" blockquote moved from Our Approach to the end of the Why section. Our Approach keeps its heading and body paragraph.

## Follow-ups (tracked in ClickUp)

- [Our Approach blockquote — redesign](https://app.clickup.com/t/868jbhjat)
- [CFP-as-hero restructure](https://app.clickup.com/t/868jbhfeu)
- [Image swap — align with UNESCO IDIL](https://app.clickup.com/t/868jbhffv)

All nested under [[NewCommons26] Internal Review - 4/21](https://app.clickup.com/t/868jbhj8k).

## Test plan

- [ ] Visit `/incubator/indigenous-languages` — h3 "Throughout the programming, participants will:" sits close to its bullet list, with the gap between title and bullets matching the gap between bullets themselves.
- [ ] Visit `/incubator/indigenous-languages` — the blockquote now lives at the end of the Why section; Our Approach shows heading + body paragraph only.
- [ ] Visit `/incubator/2026` — Programmatic Offerings right column has the same tightened spacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)