### PR TITLE
content(faq): remove "(TBC)" qualifier from Applications Open

### DIFF
--- a/pages/faq.vue
+++ b/pages/faq.vue
@@ -43,7 +43,7 @@ const faq = {
       content: `
         <p>The Incubator will follow the schedule outlined below:</p>
         <ul>
-          <li><strong>Applications Open:</strong> May (TBC)</li>
+          <li><strong>Applications Open:</strong> May</li>
           <li><strong>Informational Webinars:</strong> w/o 25 May 2026 and 1 June 2026</li>
           <li><strong>Applications Close:</strong> 10 July 2026</li>
           <li><strong>Cohort Selection:</strong> Late August</li>


### PR DESCRIPTION
## Summary

Tiny fix from Aline's Apr 17 review — removes the \"(TBC)\" qualifier from the FAQ's \"Applications Open: May\" line. The fix already exists inside PR #17, but since PR #18 was closed today and PR #17's merge timeline is independent, applying this directly so dev has the corrected copy now.

## Test plan

- [ ] Visit \`/faq\` — the \"What are the key deadlines and program milestones?\" answer reads \"Applications Open: May\" (no \"(TBC)\").

Closes the one item from task [868ja8xnk](https://app.clickup.com/t/868ja8xnk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)