### PR TITLE
feat(feedback): add CCM feedback widget to site head

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -40,6 +40,12 @@ export default defineNuxtConfig({
       ],
       script: [
         { src: 'https://player.vimeo.com/api/player.js', async: true },
+        {
+          src: 'https://ccm-feedback-582.netlify.app/w.js',
+          'data-project': 'New Commons',
+          'data-force-show': 'true',
+          defer: true,
+        },
       ],
     }
   },


### PR DESCRIPTION
## Summary
- Load CCM feedback widget (`ccm-feedback-582.netlify.app/w.js`) on all pages via Nuxt head script
- Scoped to `data-project="New Commons"` (matches project row `2667756a7bc74a279760387a92cf576d` in feedback DB)
- `data-force-show="true"` enabled so widget appears on dev preview (Netlify `NODE_ENV=production` hides by default)

## Test plan
- [ ] Netlify deploys dev--new-commons.netlify.app
- [ ] Visit site at desktop viewport (≥768px) → blue FAB bottom-right
- [ ] Click crosshair → hover element → click → comment → submit
- [ ] Feedback row appears in FeedbackItem table scoped to correct projectId
- [ ] Remove `data-force-show` before shipping to production if widget should be hidden on live site

🤖 Generated with [Claude Code](https://claude.com/claude-code)