### PR TITLE
fix(feedback): gate CCM widget to non-production builds

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,6 +4,19 @@ const title = 'New Commons'
 const description = 'How can AI reflect diverse knowledge, tackle global challenges, and remain ethical? Responsible data commons can unlock AI’s potential for the public good by enhancing data diversity, quality, and provenance.'
 const claritySnippet = `!function(c,l,a,r,i,t,y){function sync(){(new Image).src="https://c.clarity.ms/c.gif"}"complete"==document.readyState?sync():window.addEventListener("load",sync);a[c]("metadata",(function(){a[c]("set","C_IS","0")}),!1,!0);if(a[c].v||a[c].t)return a[c]("event",c,"dup."+i.projectId);a[c].t=!0,(t=l.createElement(r)).async=!0,t.src="https://scripts.clarity.ms/0.8.41/clarity.js",(y=l.getElementsByTagName(r)[0]).parentNode.insertBefore(t,y),a[c]("start",i),a[c].q.unshift(a[c].q.pop()),a[c]("set","C_IS","0")}("clarity",document,window,"script",{"projectId":"t7oy6y6059","upload":"https://i.clarity.ms/collect","expire":365,"cookies":["_uetmsclkid","_uetvid"],"track":true,"content":true,"report":"https://report.clarity.ms/eus2-tag","keep":["msclkid"],"dob":2148});`
 
+const isProduction = process.env.CONTEXT
+  ? process.env.CONTEXT === 'production'
+  : process.env.NODE_ENV === 'production'
+
+const feedbackWidgetScript = isProduction
+  ? []
+  : [{
+      src: 'https://ccm-feedback-582.netlify.app/w.js',
+      'data-project': 'new-commons',
+      'data-theme': 'auto',
+      defer: true,
+    }]
+
 export default defineNuxtConfig({
   compatibilityDate: '2024-11-01',
   devtools: { enabled: true },
@@ -40,12 +53,7 @@ export default defineNuxtConfig({
       ],
       script: [
         { src: 'https://player.vimeo.com/api/player.js', async: true },
-        {
-          src: 'https://ccm-feedback-582.netlify.app/w.js',
-          'data-project': 'New Commons',
-          'data-force-show': 'true',
-          defer: true,
-        },
+        ...feedbackWidgetScript,
       ],
     }
   },


### PR DESCRIPTION
## Summary
- Env-gated feedback widget via `nuxt.config.ts` app.head.script
- Emits only when `CONTEXT !== "production"` (Netlify), fallback `NODE_ENV !== "production"` (localhost)
- Removes broken tag from [#25](https://github.com/ccmdesign/new-commons-nuxt/pull/25) that shipped with `data-force-show` to prod
- Correct attrs: `data-project="new-commons"`, `data-theme="auto"`, `defer`

## Test plan
- [ ] `curl -I https://ccm-feedback-582.netlify.app/w.js` returns 200
- [ ] Deploy preview: FAB renders bottom-right
- [ ] Production build: tag not emitted in `<head>`
- [ ] Local dev: widget loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)