### PR TITLE
fix(ilc): CCM feedback — button color, callout + why list typography

### DIFF
--- a/components/ncCallForProposals.vue
+++ b/components/ncCallForProposals.vue
@@ -6,7 +6,7 @@
       <p class="cfp-tagline" v-html="tagline"></p>
       <div class="cfp-actions">
         <nc-button to="/incubator/2026/application" color="primary" variant="primary">Apply Now</nc-button>
-        <nc-button v-if="showLearnMore" to="/incubator/indigenous-languages" color="primary" variant="secondary">Learn More</nc-button>
+        <nc-button v-if="showLearnMore" to="/incubator/indigenous-languages" color="white" variant="secondary">Learn More</nc-button>
       </div>
     </div>
     <template v-if="hasSecondary" #right>

--- a/pages/incubator/indigenous-languages.vue
+++ b/pages/incubator/indigenous-languages.vue
@@ -205,15 +205,11 @@ const timelineData = [
   border: 1px solid var(--primary-color-11-tint);
 
   p {
-    font-size: var(--size-1);
-    line-height: 1.4;
-    font-weight: 500;
     margin: 0;
     color: var(--base-color);
   }
 
   strong {
-    font-weight: 700;
     color: var(--primary-color);
   }
 
@@ -235,6 +231,11 @@ const timelineData = [
 
   @media (max-width: 768px) {
     grid-template-columns: 1fr;
+  }
+
+  ul,
+  li {
+    font-weight: inherit;
   }
 
   &__image {


### PR DESCRIPTION
## Summary

Applies quick CCM feedback fixes from 2026-04-22 export (3 of 7 annotations):

- **Learn More button** (`/incubator/2026`): `color="white"` on CFP banner so it renders white-outlined over teal background.
- **`.callout-quote`** (`/incubator/indigenous-languages`): body text now matches surrounding panel style (drops enlarged `size-1` and `font-weight: 500`). Box/background/strong-accent preserved.
- **`.why-section ul/li`** (`/incubator/indigenous-languages`): explicit `font-weight: inherit` so list matches the paragraph above.

## Skipped — need visual review

Flagged in annotations but not tackled here:

- Timeline (`.timeline__content`) redesign — bigger scope.
- Footer (`.footer__col1 > div`) logo reorder — layout change.
- `.programmatic-offerings__list` gap vs left panel (both pages) — stack math already identical in CSS; needs browser diagnosis.

## Test plan

- [ ] `/incubator/2026` hero: verify Learn More button renders white (outline + text) on teal CFP banner.
- [ ] `/incubator/indigenous-languages` Why section: callout card text matches paragraph body style; `strong` accent still primary color.
- [ ] `/incubator/indigenous-languages` Why section: bullet list weight visually matches the "Indigenous languages face many pressures…" paragraph above.
- [ ] Light and dark modes both checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)