### PR TITLE
fix(footer,ilc): CCM feedback round 2 — footer logos + list gap

### DIFF
--- a/components/ncCallForProposals.vue
+++ b/components/ncCallForProposals.vue
@@ -6,7 +6,7 @@
       <p class="cfp-tagline" v-html="tagline"></p>
       <div class="cfp-actions">
         <nc-button to="/incubator/2026/application" color="primary" variant="primary">Apply Now</nc-button>
-        <nc-button v-if="showLearnMore" to="/incubator/indigenous-languages" color="primary" variant="secondary">Learn More</nc-button>
+        <nc-button v-if="showLearnMore" to="/incubator/indigenous-languages" color="white" variant="secondary">Learn More</nc-button>
       </div>
     </div>
     <template v-if="hasSecondary" #right>

--- a/components/ncFooter.vue
+++ b/components/ncFooter.vue
@@ -6,11 +6,6 @@
     <div class="footer__col1 footer__content">
       <h3>About ODPL</h3>
       <p>The Open Data Policy Lab supports decision-makers at the local, state and national levels as they accelerate the responsible re-use and opening of data for the benefit of society and the equitable spread of economic opportunity.</p>
-      <div class="logos">
-        <nc-odpl-logo />
-        <nc-ms-logo />
-        <nc-gov-lab-logo />
-      </div>
     </div>
     <div class="footer__col2 footer__content">
       <h3>Follow Us</h3>
@@ -27,6 +22,13 @@
           <nc-unesco-logo />
           <nc-ms-logo />
         </div>
+      </div>
+    </div>
+    <div class="footer__odpl-logos footer__content">
+      <div class="logos">
+        <nc-odpl-logo />
+        <nc-ms-logo />
+        <nc-gov-lab-logo />
       </div>
     </div>
     <by-line />
@@ -78,13 +80,15 @@
 .footer__logo,
 .footer__col1,
 .footer__col2,
-.footer__col3 {
+.footer__col3,
+.footer__odpl-logos {
   grid-column: content-start / content-end;
   grid-template-rows: auto;
 }
 
 .footer__col2,
-.footer__col3 {
+.footer__col3,
+.footer__odpl-logos {
   margin-top: var(--space-xl);
 }
 
@@ -107,9 +111,14 @@
     margin-top: 0;
   }
 
+  .footer__odpl-logos {
+    grid-column: col6 / content-end;
+    margin-top: var(--space-l-xl);
+  }
+
   .footer {
     /* Aux styles */
-    
+
   }
 }
 </style>

--- a/pages/incubator/2026.vue
+++ b/pages/incubator/2026.vue
@@ -148,7 +148,7 @@ useSeoMeta({
     ul {
       list-style: none;
       padding: 0;
-      margin: 0;
+      margin-inline: 0;
       display: flex;
       flex-direction: column;
       gap: var(--space-s);

--- a/pages/incubator/indigenous-languages.vue
+++ b/pages/incubator/indigenous-languages.vue
@@ -307,7 +307,7 @@ const timelineData = [
     ul {
       list-style: none;
       padding: 0;
-      margin: 0;
+      margin-inline: 0;
       display: flex;
       flex-direction: column;
       gap: var(--space-s);

--- a/pages/incubator/indigenous-languages.vue
+++ b/pages/incubator/indigenous-languages.vue
@@ -205,15 +205,11 @@ const timelineData = [
   border: 1px solid var(--primary-color-11-tint);
 
   p {
-    font-size: var(--size-1);
-    line-height: 1.4;
-    font-weight: 500;
     margin: 0;
     color: var(--base-color);
   }
 
   strong {
-    font-weight: 700;
     color: var(--primary-color);
   }
 
@@ -235,6 +231,11 @@ const timelineData = [
 
   @media (max-width: 768px) {
     grid-template-columns: 1fr;
+  }
+
+  ul,
+  li {
+    font-weight: inherit;
   }
 
   &__image {


### PR DESCRIPTION
## Summary

Round 2 of CCM feedback fixes (2 of the remaining 3).

**Footer logo reorder** — `components/ncFooter.vue`
The ODPL / Microsoft / GovLab logos moved out of `.footer__col1` into a new row that spans `col6 / content-end` on desktop (sits under Follow Us + Partners). On mobile they stack in document order after Partners.

**Programmatic offerings list gap** — `pages/incubator/2026.vue` and `pages/incubator/indigenous-languages.vue`
Root cause was a specificity fight: `.programmatic-offerings__list ul { margin: 0 }` (0,2,1) was beating `.stack > * + * { margin-block-start: var(--_stack-space) }` (0,2,0), zeroing the block margin `.stack` uses to space the heading from the list. Swapped `margin: 0` → `margin-inline: 0` so the override is scoped to the inline axis and `.stack` can control vertical rhythm. Result: gap matches the left panel's heading→paragraph spacing.

## Skipped

Timeline redesign on `/incubator/indigenous-languages` — bigger scope, handled separately.

## Test plan

- [ ] `/incubator/2026` footer desktop: three ODPL/MS/GovLab logos sit below Follow Us and Partners, aligned with `col6..content-end`.
- [ ] Footer mobile: logos stack cleanly after Partners, spaced by `--space-xl`.
- [ ] `/incubator/2026` Programmatic Offerings: gap between `Throughout the programming, participants will:` and the list matches the heading→paragraph gap in the left panel.
- [ ] Same check on `/incubator/indigenous-languages`.
- [ ] No other pages regressed by footer change (same component used globally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)